### PR TITLE
feat: add Swagger documentation to backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Node dependencies
+**/node_modules/
+
+# Environment variables
+.env

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,8 @@
     "sqlite3": "^5.1.6",
     "dotenv": "^16.3.1",
     "helmet": "^7.1.0",
-    "express-rate-limit": "^7.1.5"
+    "express-rate-limit": "^7.1.5",
+    "swagger-ui-express": "^4.7.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"
@@ -31,4 +32,3 @@
   "author": "Codex",
   "license": "MIT"
 }
-

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,8 @@ const cors = require('cors');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const path = require('path');
+const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = require('./swagger.json');
 
 // Importar rotas
 const authRoutes = require('./routes/auth');
@@ -72,6 +74,9 @@ app.get('/health', (req, res) => {
     uptime: process.uptime()
   });
 });
+
+// Documentação Swagger
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 // Rotas de autenticação (aplicar rate limiting específico)
 app.use('/auth/login', loginLimiter);

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Backend API",
+    "version": "1.0.0",
+    "description": "Documentação da API do backend"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Servidor local"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Verificar status do servidor",
+        "responses": {
+          "200": {
+            "description": "Status de funcionamento do servidor"
+          }
+        }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "summary": "Autenticar usuário",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": { "type": "string" },
+                  "password": { "type": "string" }
+                },
+                "required": ["username", "password"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Login realizado com sucesso" },
+          "401": { "description": "Credenciais inválidas" }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "summary": "Logout do usuário",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": { "description": "Logout realizado com sucesso" },
+          "401": { "description": "Usuário não autorizado" }
+        }
+      }
+    },
+    "/dashboard": {
+      "get": {
+        "summary": "Obter dados do dashboard",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": { "description": "Dados do dashboard" },
+          "401": { "description": "Usuário não autorizado" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- serve auto-generated Swagger documentation under `/api-docs`
- add OpenAPI definition for health, auth and dashboard endpoints
- ignore node_modules directories

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689246fb2714832eb50030cd21238fb3