### PR TITLE
fix: enable trust proxy for rate limiting

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -23,6 +23,9 @@ const { authenticateToken } = require('./middleware/auth');
 const { initDatabase } = require('./config/database');
 
 const app = express();
+// Confiar no primeiro proxy para que o express-rate-limit
+// identifique corretamente o IP do cliente quando X-Forwarded-For estiver presente
+app.set('trust proxy', 1);
 const PORT = process.env.PORT || 3000;
 
 // Configurações de segurança


### PR DESCRIPTION
## Summary
- enable Express trust proxy so rate limiting works when `X-Forwarded-For` header is present

## Testing
- `npm test` (fails: Missing script "test")
- `node server.js` and `curl -H "X-Forwarded-For: 1.2.3.4" http://localhost:3000/health`


------
https://chatgpt.com/codex/tasks/task_e_6892542b2c18832e891b624d6978b3c3