### PR TITLE
feat(frontend): load API URL from environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # Environment variables
 .env
+**/.env

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ DB_PATH=./database/users.db
 CORS_ORIGIN=http://localhost:4200
 ```
 
+Para o frontend, crie um arquivo `.env` dentro da pasta `frontend/` definindo a URL da API:
+
+```env
+NG_APP_API_URL=http://localhost:3000
+```
+
 ## 🚀 Executando o Projeto
 
 ### Opção 1: Executar frontend e backend juntos (Recomendado)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NG_APP_API_URL=http://localhost:3000

--- a/frontend/src/app/services/api.ts
+++ b/frontend/src/app/services/api.ts
@@ -5,13 +5,14 @@
 
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable, catchError, throwError } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ApiService {
-  private readonly API_URL = 'http://localhost:3000';
+  private readonly API_URL = environment.apiUrl;
 
   constructor(private http: HttpClient) {}
 

--- a/frontend/src/app/services/auth.ts
+++ b/frontend/src/app/services/auth.ts
@@ -5,6 +5,7 @@
 
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { BehaviorSubject, Observable, tap, catchError, throwError } from 'rxjs';
 import { Router } from '@angular/router';
 
@@ -37,7 +38,7 @@ export interface AuthState {
   providedIn: 'root'
 })
 export class AuthService {
-  private readonly API_URL = 'http://localhost:3000';
+  private readonly API_URL = environment.apiUrl;
   private readonly TOKEN_KEY = 'auth_token';
   private readonly USER_KEY = 'auth_user';
 

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: (import.meta as any).env['NG_APP_API_URL'] || 'http://localhost:3000',
+};


### PR DESCRIPTION
## Summary
- use NG_APP_API_URL to configure frontend API URL
- document NG_APP_API_URL and provide example .env file

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:frontend` *(fails: Failed to inline external stylesheet from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689257993790832e8848f8ecb4ee0cc8