### PR TITLE
feat: add production environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,8 @@ DB_PASSWORD=postgres
 CORS_ORIGIN=http://localhost:4200
 ```
 
-Para o frontend, crie um arquivo `.env` dentro da pasta `frontend/` definindo a URL da API:
-
-```env
-NG_APP_API_URL=http://localhost:3000
-```
+Para o frontend em produção, defina a variável de ambiente `NG_APP_API_URL` com a URL da API antes de executar o build.
+Em desenvolvimento, o arquivo `src/environments/environment.ts` já utiliza `http://localhost:3000` por padrão.
 
 ## 🚀 Executando o Projeto
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -63,6 +63,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.production.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/frontend/src/environments/environment.production.ts
+++ b/frontend/src/environments/environment.production.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: (import.meta as any).env['NG_APP_API_URL']
+};

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,3 +1,3 @@
 export const environment = {
-  apiUrl: (import.meta as any).env['NG_APP_API_URL'] || 'http://localhost:3000',
+  apiUrl: 'http://localhost:3000',
 };


### PR DESCRIPTION
## Summary
- set development API URL to localhost
- introduce `environment.production` and configure Angular build to use it
- document production API URL environment variable usage

## Testing
- `NG_APP_API_URL=http://localhost:3000 npm run build` *(fails: Inlining of fonts failed with status code 403)*


------
https://chatgpt.com/codex/tasks/task_e_689397a790ec832ea4a07def96dad628