### PR TITLE
fix: downgrade tailwind to v3 and adjust PostCSS config

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,9 +36,8 @@
     "@angular/cli": "^20.1.4",
     "@angular/compiler-cli": "^20.1.0",
     "autoprefixer": "^10.4.20",
-    "@tailwindcss/postcss": "^4.1.11",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.11",
+    "tailwindcss": "^3.4.4",
     "typescript": "~5.8.2"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- downgrade tailwind to 3.4.4 and remove @tailwindcss/postcss
- configure PostCSS to use tailwindcss plugin

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tailwindcss)*
- `npm run build` *(fails: Error: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin ... )*

------
https://chatgpt.com/codex/tasks/task_e_6893a6ab88cc832e9230232e7e887026