### PR TITLE
refactor: replace form labels with tailwind classes

### DIFF
--- a/frontend/src/app/components/login/login.html
+++ b/frontend/src/app/components/login/login.html
@@ -15,7 +15,7 @@
         <form (ngSubmit)="onSubmit()" #loginForm="ngForm">
           <!-- Campo Username -->
           <div class="mb-6">
-            <label for="username" class="form-label">
+            <label for="username" class="block text-sm font-medium text-gray-700 mb-2">
               <i class="pi pi-user mr-2"></i>
               Usuário ou Email
             </label>
@@ -33,7 +33,7 @@
 
           <!-- Campo Password -->
           <div class="mb-6">
-            <label for="password" class="form-label">
+            <label for="password" class="block text-sm font-medium text-gray-700 mb-2">
               <i class="pi pi-lock mr-2"></i>
               Senha
             </label>

--- a/frontend/src/app/components/reset-password/reset-password.html
+++ b/frontend/src/app/components/reset-password/reset-password.html
@@ -3,11 +3,11 @@
     <h2 class="text-2xl font-bold mb-4">Redefinir Senha</h2>
     <form (ngSubmit)="onSubmit()" #f="ngForm" class="space-y-4">
       <div>
-        <label for="email" class="form-label">Email</label>
+        <label for="email" class="block text-sm font-medium text-gray-700 mb-2">Email</label>
         <input pInputText id="email" name="email" [(ngModel)]="email" required class="w-full" />
       </div>
       <div>
-        <label for="password" class="form-label">Nova Senha</label>
+        <label for="password" class="block text-sm font-medium text-gray-700 mb-2">Nova Senha</label>
         <p-password [(ngModel)]="password" name="password" required [feedback]="false" placeholder="Nova senha" styleClass="w-full" inputStyleClass="w-full"></p-password>
       </div>
       <p-button type="submit" label="Redefinir" [disabled]="!f.valid || isLoading" [loading]="isLoading" styleClass="w-full"></p-button>

--- a/frontend/src/app/components/users/user-form.html
+++ b/frontend/src/app/components/users/user-form.html
@@ -3,19 +3,19 @@
     <h2 class="text-xl font-bold mb-4">{{ isEdit ? 'Editar Usuário' : 'Novo Usuário' }}</h2>
     <form (ngSubmit)="onSubmit()" #f="ngForm" class="space-y-4">
       <div>
-        <label class="form-label" for="username">Usuário</label>
+        <label class="block text-sm font-medium text-gray-700 mb-2" for="username">Usuário</label>
         <input pInputText id="username" name="username" [(ngModel)]="user.username" required class="w-full" />
       </div>
       <div>
-        <label class="form-label" for="email">Email</label>
+        <label class="block text-sm font-medium text-gray-700 mb-2" for="email">Email</label>
         <input pInputText id="email" name="email" [(ngModel)]="user.email" required class="w-full" />
       </div>
       <div>
-        <label class="form-label" for="fullName">Nome Completo</label>
+        <label class="block text-sm font-medium text-gray-700 mb-2" for="fullName">Nome Completo</label>
         <input pInputText id="fullName" name="fullName" [(ngModel)]="user.fullName" class="w-full" />
       </div>
       <div>
-        <label class="form-label" for="password">Senha</label>
+        <label class="block text-sm font-medium text-gray-700 mb-2" for="password">Senha</label>
         <p-password id="password" name="password" [(ngModel)]="user.password" [feedback]="false" placeholder="Senha" styleClass="w-full" inputStyleClass="w-full" [required]="!isEdit"></p-password>
       </div>
       <p-button type="submit" label="Salvar" [disabled]="!f.valid || isLoading" [loading]="isLoading"></p-button>


### PR DESCRIPTION
## Summary
- replace legacy `.form-label` classes with Tailwind utilities in login, reset password, and user form components

## Testing
- `npm run build:frontend`


------
https://chatgpt.com/codex/tasks/task_e_6893ab696ab8832e83041a6fccf3e88c