### PR TITLE
Disable Tailwind preflight to avoid PrimeNG style conflicts

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./src/**/*.{html,ts}"],
+  corePlugins: { preflight: false },
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- disable Tailwind CSS preflight resets to prevent conflicts with PrimeNG styles

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893b0e998d0832e978cd9b370e2f068