### PR TITLE
chore: include PrimeNG theme styles

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -59,6 +59,8 @@
             ],
             "styles": [
               "node_modules/primeicons/primeicons.css",
+              "node_modules/primeng/resources/themes/lara-light-blue/theme.css",
+              "node_modules/primeng/resources/primeng.min.css",
               "src/styles.scss"
             ]
           },


### PR DESCRIPTION
## Summary
- include Lara Light Blue theme and core PrimeNG styles in Angular build config

## Testing
- `npm run build` (fails: Could not resolve node_modules/primeng/resources/themes/lara-light-blue/theme.css)

------
https://chatgpt.com/codex/tasks/task_e_6893b0e84a98832ebb7bcce71c389a0a