### PR TITLE
chore: remove deprecated primeng-sass-theme dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,6 @@
         "@angular/router": "^20.1.0",
         "primeicons": "7.0.0",
         "primeng": "20.0.1",
-        "primeng-sass-theme": "^17.9.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -7061,12 +7060,6 @@
         "@angular/router": "^20.0.4",
         "rxjs": "^6.0.0 || ^7.8.1"
       }
-    },
-    "node_modules/primeng-sass-theme": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/primeng-sass-theme/-/primeng-sass-theme-17.9.0.tgz",
-      "integrity": "sha512-ErifhxX98aA+P4ofPbZuoDMS3pnQDtbfvpma1bFPAxuDRFijPapDtclx/jQdwq5qLLs9fTn3Jr4VZTMpoTSK/g==",
-      "license": "MIT"
     },
     "node_modules/proc-log": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,6 @@
     "@angular/router": "^20.1.0",
     "primeicons": "7.0.0",
     "primeng": "20.0.1",
-    "primeng-sass-theme": "^17.9.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"


### PR DESCRIPTION
## Summary
- remove legacy `primeng-sass-theme` from frontend dependencies
- update lockfile after dependency cleanup

## Testing
- `npm run build` (fails: Could not resolve module paths and styles)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6893be529a04832e9b5fb23b2bfc459e