### PR TITLE
chore: update primeng css reference

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -60,7 +60,7 @@
             "styles": [
               "node_modules/primeicons/primeicons.css",
               "node_modules/primeng/resources/themes/lara-light-blue/theme.css",
-              "node_modules/primeng/resources/primeng.min.css",
+              "node_modules/primeng/resources/primeng.css",
               "src/styles.scss"
             ]
           },


### PR DESCRIPTION
## Summary
- reference non-minified PrimeNG stylesheet in Angular config

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build:frontend` (fails: TS2307 Cannot find module 'primeng/card/card')

------
https://chatgpt.com/codex/tasks/task_e_6893be524dac832e8a5e91ae0a6dc197