### PR TITLE
refactor: simplify primeng import paths

### DIFF
--- a/frontend/src/app/components/dashboard/dashboard.ts
+++ b/frontend/src/app/components/dashboard/dashboard.ts
@@ -9,12 +9,12 @@ import { Router } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 
 // PrimeNG imports
-import { CardModule } from 'primeng/card/card';
-import { ButtonModule } from 'primeng/button/button';
+import { CardModule } from 'primeng/card';
+import { ButtonModule } from 'primeng/button';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { ProgressBarModule } from 'primeng/progressbar';
-import { ToastModule } from 'primeng/toast/toast';
+import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 import { AvatarModule } from 'primeng/avatar';
 import { MenuModule } from 'primeng/menu';

--- a/frontend/src/app/components/login/login.ts
+++ b/frontend/src/app/components/login/login.ts
@@ -9,12 +9,12 @@ import { FormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterModule } from '@angular/router';
 
 // PrimeNG imports
-import { ButtonModule } from 'primeng/button/button';
-import { InputTextModule } from 'primeng/inputtext/inputtext';
-import { PasswordModule } from 'primeng/password/password';
-import { CardModule } from 'primeng/card/card';
+import { ButtonModule } from 'primeng/button';
+import { InputTextModule } from 'primeng/inputtext';
+import { PasswordModule } from 'primeng/password';
+import { CardModule } from 'primeng/card';
 import { MessageModule } from 'primeng/message';
-import { ToastModule } from 'primeng/toast/toast';
+import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { AuthService, LoginRequest } from '../../services/auth';

--- a/frontend/src/app/components/reset-password/reset-password.ts
+++ b/frontend/src/app/components/reset-password/reset-password.ts
@@ -9,11 +9,11 @@ import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 
 // PrimeNG
-import { CardModule } from 'primeng/card/card';
-import { InputTextModule } from 'primeng/inputtext/inputtext';
-import { PasswordModule } from 'primeng/password/password';
-import { ButtonModule } from 'primeng/button/button';
-import { ToastModule } from 'primeng/toast/toast';
+import { CardModule } from 'primeng/card';
+import { InputTextModule } from 'primeng/inputtext';
+import { PasswordModule } from 'primeng/password';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { AuthService } from '../../services/auth';

--- a/frontend/src/app/components/users/user-form.ts
+++ b/frontend/src/app/components/users/user-form.ts
@@ -9,11 +9,11 @@ import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
 // PrimeNG
-import { CardModule } from 'primeng/card/card';
-import { InputTextModule } from 'primeng/inputtext/inputtext';
-import { PasswordModule } from 'primeng/password/password';
-import { ButtonModule } from 'primeng/button/button';
-import { ToastModule } from 'primeng/toast/toast';
+import { CardModule } from 'primeng/card';
+import { InputTextModule } from 'primeng/inputtext';
+import { PasswordModule } from 'primeng/password';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { UserService, AppUser } from '../../services/users';

--- a/frontend/src/app/components/users/user-list.ts
+++ b/frontend/src/app/components/users/user-list.ts
@@ -9,8 +9,8 @@ import { Router } from '@angular/router';
 
 // PrimeNG
 import { TableModule } from 'primeng/table';
-import { ButtonModule } from 'primeng/button/button';
-import { ToastModule } from 'primeng/toast/toast';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { UserService, AppUser } from '../../services/users';


### PR DESCRIPTION
## Summary
- simplify PrimeNG import statements across components

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893be520f1c832eace577820955247b