### PR TITLE
docs: remove tailwind references

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,10 @@
 
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.1.4.
 
+## Styling
+
+The UI is built with [PrimeNG](https://primeng.org) components and custom SCSS defined in `src/styles.scss`.
+
 ## Development server
 
 To start a local development server, run:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fullstack-angular-nodejs",
   "version": "1.0.0",
-  "description": "Projeto fullstack com Angular (PrimeNG + TailwindCSS) e Node.js (Express + JWT)",
+  "description": "Projeto fullstack com Angular (PrimeNG + CSS customizado) e Node.js (Express + JWT)",
   "scripts": {
     "install:backend": "cd backend && npm install",
     "install:frontend": "cd frontend && npm install",
@@ -22,7 +22,6 @@
     "express",
     "jwt",
     "primeng",
-    "tailwindcss",
     "fullstack"
   ],
   "author": "Codex",


### PR DESCRIPTION
## Summary
- remove tailwind mention from package description and keywords
- clarify frontend styling relies on PrimeNG and custom SCSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68940d9def48832ea20bae94734f5161