### PR TITLE
refactor: remove tailwind classes from auth & user components

### DIFF
--- a/frontend/src/app/components/login/login.html
+++ b/frontend/src/app/components/login/login.html
@@ -1,24 +1,18 @@
-<div class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
-  <div class="w-full max-w-md">
-    <!-- Logo/Header -->
-    <div class="text-center mb-8">
-      <div class="inline-flex items-center justify-center w-16 h-16 bg-indigo-600 rounded-full mb-4">
-        <i class="pi pi-lock text-white text-2xl"></i>
+<div class="login-container">
+  <div class="content">
+    <div class="logo">
+      <div class="logo-circle">
+        <i class="pi pi-lock"></i>
       </div>
-      <h1 class="text-3xl font-bold text-gray-900 mb-2">Bem-vindo</h1>
-      <p class="text-gray-600">Faça login para acessar o dashboard</p>
+      <h1>Bem-vindo</h1>
+      <p>Faça login para acessar o dashboard</p>
     </div>
 
-    <!-- Card de Login com PrimeNG -->
-    <p-card styleClass="rounded-xl shadow-xl border-0" contentStyleClass="p-0">
-      <div class="p-6">
-        <form (ngSubmit)="onSubmit()" #loginForm="ngForm" novalidate>
-          <!-- Campo Username -->
-          <div class="mb-6">
-            <label for="username" class="block text-sm font-medium text-gray-700 mb-1">
-              <i class="pi pi-user mr-2"></i>
-              Usuário ou Email
-            </label>
+    <p-card class="login-card" contentStyleClass="no-padding">
+      <div class="card-content">
+        <form (ngSubmit)="onSubmit()" #loginForm="ngForm" novalidate class="form">
+          <div class="field">
+            <label for="username"><i class="pi pi-user mr-2"></i>Usuário ou Email</label>
             <input
               pInputText
               id="username"
@@ -26,18 +20,14 @@
               [(ngModel)]="credentials.username"
               required
               type="text"
-              class="w-full rounded-md border border-gray-300 focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 px-4 py-2"
+              class="w-full"
               placeholder="Digite seu usuário ou email"
               [disabled]="isLoading"
             />
           </div>
 
-          <!-- Campo Password -->
-          <div class="mb-6">
-            <label for="password" class="block text-sm font-medium text-gray-700 mb-1">
-              <i class="pi pi-lock mr-2"></i>
-              Senha
-            </label>
+          <div class="field">
+            <label for="password"><i class="pi pi-lock mr-2"></i>Senha</label>
             <p-password
               [(ngModel)]="credentials.password"
               name="password"
@@ -46,45 +36,30 @@
               [toggleMask]="true"
               placeholder="Digite sua senha"
               styleClass="w-full"
-              inputStyleClass="w-full rounded-md border border-gray-300 focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 px-4 py-2"
+              inputStyleClass="w-full"
               [disabled]="isLoading"
             ></p-password>
           </div>
 
-          <!-- Mensagem de Erro -->
-          <div *ngIf="errorMessage" class="mb-4">
-            <p-message
-              severity="error"
-              [text]="errorMessage"
-              styleClass="rounded-lg border-0 px-4 py-2 bg-red-100 text-red-700"
-            ></p-message>
+          <div *ngIf="errorMessage" class="error-msg">
+            <p-message severity="error" [text]="errorMessage"></p-message>
           </div>
 
-          <!-- Botão de Login -->
           <p-button
             type="submit"
             label="Entrar"
             icon="pi pi-sign-in"
             [loading]="isLoading"
             [disabled]="!loginForm.valid || isLoading"
-            styleClass="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-3 rounded-lg transition-colors duration-200 disabled:opacity-50"
+            styleClass="w-full"
           ></p-button>
 
-          <a
-            routerLink="/reset-password"
-            class="block text-center mt-4 text-sm text-blue-600 hover:underline"
-          >
-            Esqueci minha senha
-          </a>
+          <a routerLink="/reset-password" class="forgot-link">Esqueci minha senha</a>
         </form>
 
-        <!-- Informações de Teste -->
-        <div class="mt-6 p-4 bg-blue-50 rounded-lg border border-blue-200">
-          <h3 class="text-sm font-medium text-blue-800 mb-2">
-            <i class="pi pi-info-circle mr-1"></i>
-            Credenciais de Teste
-          </h3>
-          <div class="text-sm text-blue-700">
+        <div class="info-box">
+          <h3><i class="pi pi-info-circle mr-1"></i>Credenciais de Teste</h3>
+          <div class="credentials">
             <p><strong>Usuário:</strong> admin</p>
             <p><strong>Senha:</strong> admin123</p>
           </div>
@@ -92,12 +67,10 @@
       </div>
     </p-card>
 
-    <!-- Footer -->
-    <div class="text-center mt-8 text-gray-500 text-sm">
+    <div class="footer">
       <p>© 2024 Fullstack App. Desenvolvido com Angular + Node.js</p>
     </div>
   </div>
 </div>
 
-<!-- Toast para notificações -->
 <p-toast></p-toast>

--- a/frontend/src/app/components/login/login.scss
+++ b/frontend/src/app/components/login/login.scss
@@ -1,0 +1,106 @@
+.login-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(to bottom right, #eff6ff, #e0e7ff);
+  padding: 1rem;
+}
+
+.content {
+  width: 100%;
+  max-width: 28rem;
+}
+
+.logo {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.logo-circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+  background: #4f46e5;
+  margin: 0 auto 1rem;
+}
+
+.logo-circle i {
+  color: #fff;
+  font-size: 2rem;
+}
+
+.logo h1 {
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 0.5rem;
+}
+
+.logo p {
+  color: #4b5563;
+}
+
+.login-card .card-content {
+  padding: 1.5rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.field label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.25rem;
+}
+
+.error-msg p-message {
+  display: block;
+  border: 0;
+  padding: 0.5rem 1rem;
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.forgot-link {
+  display: block;
+  text-align: center;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: #2563eb;
+}
+
+.info-box {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+}
+
+.info-box h3 {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #1e40af;
+  margin-bottom: 0.5rem;
+}
+
+.info-box .credentials {
+  font-size: 0.875rem;
+  color: #1e3a8a;
+}
+
+.footer {
+  text-align: center;
+  margin-top: 2rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+}

--- a/frontend/src/app/components/login/login.ts
+++ b/frontend/src/app/components/login/login.ts
@@ -35,6 +35,7 @@ import { AuthService, LoginRequest } from '../../services/auth';
   ],
   providers: [MessageService],
   templateUrl: './login.html',
+  styleUrls: ['./login.scss'],
 })
 export class LoginComponent implements OnInit {
   credentials: LoginRequest = {

--- a/frontend/src/app/components/reset-password/reset-password.html
+++ b/frontend/src/app/components/reset-password/reset-password.html
@@ -1,13 +1,13 @@
-<div class="min-h-screen flex items-center justify-center bg-gray-100 p-4">
-  <p-card class="w-full max-w-md">
-    <h2 class="text-2xl font-bold mb-4">Redefinir Senha</h2>
-    <form (ngSubmit)="onSubmit()" #f="ngForm" class="space-y-4">
+<div class="reset-password">
+  <p-card class="form-card">
+    <h2 class="title">Redefinir Senha</h2>
+    <form (ngSubmit)="onSubmit()" #f="ngForm" class="form">
       <div>
-        <label for="email" class="block text-sm font-medium text-gray-700 mb-2">Email</label>
+        <label for="email">Email</label>
         <input pInputText id="email" name="email" [(ngModel)]="email" required class="w-full" />
       </div>
       <div>
-        <label for="password" class="block text-sm font-medium text-gray-700 mb-2">Nova Senha</label>
+        <label for="password">Nova Senha</label>
         <p-password [(ngModel)]="password" name="password" required [feedback]="false" placeholder="Nova senha" styleClass="w-full" inputStyleClass="w-full"></p-password>
       </div>
       <p-button type="submit" label="Redefinir" [disabled]="!f.valid || isLoading" [loading]="isLoading" styleClass="w-full"></p-button>

--- a/frontend/src/app/components/reset-password/reset-password.scss
+++ b/frontend/src/app/components/reset-password/reset-password.scss
@@ -1,0 +1,33 @@
+.reset-password {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f3f4f6;
+  padding: 1rem;
+}
+
+.form-card {
+  width: 100%;
+  max-width: 28rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/app/components/reset-password/reset-password.ts
+++ b/frontend/src/app/components/reset-password/reset-password.ts
@@ -31,7 +31,8 @@ import { AuthService } from '../../services/auth';
     ToastModule
   ],
   providers: [MessageService],
-  templateUrl: './reset-password.html'
+  templateUrl: './reset-password.html',
+  styleUrls: ['./reset-password.scss']
 })
 export class ResetPasswordComponent {
   email = '';

--- a/frontend/src/app/components/users/user-form.html
+++ b/frontend/src/app/components/users/user-form.html
@@ -1,21 +1,21 @@
-<div class="p-4">
-  <p-card class="max-w-xl mx-auto">
-    <h2 class="text-xl font-bold mb-4">{{ isEdit ? 'Editar Usuário' : 'Novo Usuário' }}</h2>
-    <form (ngSubmit)="onSubmit()" #f="ngForm" class="space-y-4">
+<div class="user-form-container">
+  <p-card class="form-card">
+    <h2 class="title">{{ isEdit ? 'Editar Usuário' : 'Novo Usuário' }}</h2>
+    <form (ngSubmit)="onSubmit()" #f="ngForm" class="form">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2" for="username">Usuário</label>
+        <label for="username">Usuário</label>
         <input pInputText id="username" name="username" [(ngModel)]="user.username" required class="w-full" />
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2" for="email">Email</label>
+        <label for="email">Email</label>
         <input pInputText id="email" name="email" [(ngModel)]="user.email" required class="w-full" />
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2" for="fullName">Nome Completo</label>
+        <label for="fullName">Nome Completo</label>
         <input pInputText id="fullName" name="fullName" [(ngModel)]="user.fullName" class="w-full" />
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2" for="password">Senha</label>
+        <label for="password">Senha</label>
         <p-password id="password" name="password" [(ngModel)]="user.password" [feedback]="false" placeholder="Senha" styleClass="w-full" inputStyleClass="w-full" [required]="!isEdit"></p-password>
       </div>
       <p-button type="submit" label="Salvar" [disabled]="!f.valid || isLoading" [loading]="isLoading"></p-button>

--- a/frontend/src/app/components/users/user-form.scss
+++ b/frontend/src/app/components/users/user-form.scss
@@ -1,0 +1,28 @@
+.user-form-container {
+  padding: 1rem;
+}
+
+.form-card {
+  max-width: 36rem;
+  margin: 0 auto;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/app/components/users/user-form.ts
+++ b/frontend/src/app/components/users/user-form.ts
@@ -23,7 +23,8 @@ import { UserService, AppUser } from '../../services/users';
   standalone: true,
   imports: [CommonModule, FormsModule, CardModule, InputTextModule, PasswordModule, ButtonModule, ToastModule],
   providers: [MessageService],
-  templateUrl: './user-form.html'
+  templateUrl: './user-form.html',
+  styleUrls: ['./user-form.scss']
 })
 export class UserFormComponent implements OnInit {
   user: AppUser = { username: '', email: '', fullName: '', password: '' };

--- a/frontend/src/app/components/users/user-list.html
+++ b/frontend/src/app/components/users/user-list.html
@@ -1,6 +1,6 @@
-<div class="p-4">
-  <div class="flex justify-between items-center mb-4">
-    <h2 class="text-xl font-bold">Usuários</h2>
+<div class="user-list">
+  <div class="header">
+    <h2 class="title">Usuários</h2>
     <p-button label="Novo" icon="pi pi-plus" (onClick)="createUser()"></p-button>
   </div>
   <p-table [value]="users" [loading]="isLoading">

--- a/frontend/src/app/components/users/user-list.scss
+++ b/frontend/src/app/components/users/user-list.scss
@@ -1,0 +1,15 @@
+.user-list {
+  padding: 1rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 700;
+}

--- a/frontend/src/app/components/users/user-list.ts
+++ b/frontend/src/app/components/users/user-list.ts
@@ -20,7 +20,8 @@ import { UserService, AppUser } from '../../services/users';
   standalone: true,
   imports: [CommonModule, TableModule, ButtonModule, ToastModule],
   providers: [MessageService],
-  templateUrl: './user-list.html'
+  templateUrl: './user-list.html',
+  styleUrls: ['./user-list.scss']
 })
 export class UserListComponent implements OnInit {
   users: AppUser[] = [];


### PR DESCRIPTION
## Summary
- replace tailwind-based layout in login and reset password with custom SCSS
- drop tailwind utility usage in user form and list components

## Testing
- `npm run build` *(fails: Could not resolve "node_modules/primeng/resources/themes/lara-light-blue/theme.css")*


------
https://chatgpt.com/codex/tasks/task_e_68940d9febd4832e8943e4aba75bd09a