### PR TITLE
feat: include PrimeNG styles in build

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -59,6 +59,8 @@
             ],
             "styles": [
               "node_modules/primeicons/primeicons.css",
+              "node_modules/primeng/resources/themes/aura-light-blue/theme.css",
+              "node_modules/primeng/resources/primeng.css",
               "src/styles.scss"
             ]
           },


### PR DESCRIPTION
## Summary
- include PrimeNG core and Aura theme styles in Angular build configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve theme.css and primeng.css)*

------
https://chatgpt.com/codex/tasks/task_e_689414137484832e87b8e9b3916bed14