### PR TITLE
Add toast components for user feedback

### DIFF
--- a/frontend/src/app/components/reset-password/reset-password.html
+++ b/frontend/src/app/components/reset-password/reset-password.html
@@ -1,4 +1,5 @@
 <div class="reset-password">
+  <p-toast></p-toast>
   <p-card class="form-card">
     <h2 class="title">Redefinir Senha</h2>
     <form (ngSubmit)="onSubmit()" #f="ngForm" class="form">

--- a/frontend/src/app/components/users/user-form.html
+++ b/frontend/src/app/components/users/user-form.html
@@ -1,4 +1,5 @@
 <div class="user-form-container">
+  <p-toast></p-toast>
   <p-card class="form-card">
     <h2 class="title">{{ isEdit ? 'Editar Usuário' : 'Novo Usuário' }}</h2>
     <form (ngSubmit)="onSubmit()" #f="ngForm" class="form">

--- a/frontend/src/app/components/users/user-list.html
+++ b/frontend/src/app/components/users/user-list.html
@@ -1,4 +1,5 @@
 <div class="user-list">
+  <p-toast></p-toast>
   <div class="header">
     <h2 class="title">Usuários</h2>
     <p-button label="Novo" icon="pi pi-plus" (onClick)="createUser()"></p-button>


### PR DESCRIPTION
## Summary
- add `<p-toast>` to reset password, user list, and user form templates
- ensure components continue to provide `MessageService`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:frontend`


------
https://chatgpt.com/codex/tasks/task_e_689414120b6c832ea4fe0e0759b4030d