### PR TITLE
fix: remove outdated primeng css references

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -58,9 +58,7 @@
               }
             ],
             "styles": [
-              "node_modules/primeicons/primeicons.css",
-              "node_modules/primeng/resources/themes/aura-light-blue/theme.css",
-              "node_modules/primeng/resources/primeng.css",
+              "primeicons/primeicons.css",
               "src/styles.scss"
             ]
           },


### PR DESCRIPTION
## Summary
- remove direct imports of primeng theme and base css

## Testing
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689417484f50832e9bd44e14fb553ca9