### PR TITLE
fix: display login input

### DIFF
--- a/frontend/src/app/components/login/login.html
+++ b/frontend/src/app/components/login/login.html
@@ -13,7 +13,8 @@
         <form (ngSubmit)="onSubmit()" #loginForm="ngForm" novalidate class="form">
           <div class="field">
             <label for="username"><i class="pi pi-user mr-2"></i>Usuário ou Email</label>
-            <p-inputText
+            <input
+              pInputText
               id="username"
               name="username"
               [(ngModel)]="credentials.username"
@@ -22,7 +23,7 @@
               class="w-full"
               placeholder="Digite seu usuário ou email"
               [disabled]="isLoading"
-            ></p-inputText>
+            />
           </div>
 
           <div class="field">


### PR DESCRIPTION
## Summary
- render login username field with standard input element

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894197da0a0832eb276ace2edec4796