### PR TITLE
feat: add master layout

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,15 +5,9 @@
 
 import { Routes } from '@angular/router';
 import { authGuard } from './guards/auth-guard';
+import { MasterLayoutComponent } from './components/layout/master-layout';
 
 export const routes: Routes = [
-  // Rota raiz - redireciona para dashboard
-  {
-    path: '',
-    redirectTo: '/dashboard',
-    pathMatch: 'full'
-  },
-  
   // Rota de login
   {
     path: 'login',
@@ -25,34 +19,19 @@ export const routes: Routes = [
     path: 'reset-password',
     loadComponent: () => import('./components/reset-password/reset-password').then(m => m.ResetPasswordComponent)
   },
-  
-  // Rota do dashboard (protegida)
-  {
-    path: 'dashboard',
-    loadComponent: () => import('./components/dashboard/dashboard').then(m => m.DashboardComponent),
-    canActivate: [authGuard]
-  },
 
-  // CRUD de usuários
+  // Rotas protegidas dentro do layout principal
   {
-    path: 'users',
-    loadComponent: () => import('./components/users/user-list').then(m => m.UserListComponent),
-    canActivate: [authGuard]
-  },
-  {
-    path: 'users/new',
-    loadComponent: () => import('./components/users/user-form').then(m => m.UserFormComponent),
-    canActivate: [authGuard]
-  },
-  {
-    path: 'users/:id',
-    loadComponent: () => import('./components/users/user-form').then(m => m.UserFormComponent),
-    canActivate: [authGuard]
-  },
-  
-  // Rota 404 - redireciona para dashboard
-  {
-    path: '**',
-    redirectTo: '/dashboard'
+    path: '',
+    component: MasterLayoutComponent,
+    canActivate: [authGuard],
+    children: [
+      { path: 'dashboard', loadComponent: () => import('./components/dashboard/dashboard').then(m => m.DashboardComponent) },
+      { path: 'users', loadComponent: () => import('./components/users/user-list').then(m => m.UserListComponent) },
+      { path: 'users/new', loadComponent: () => import('./components/users/user-form').then(m => m.UserFormComponent) },
+      { path: 'users/:id', loadComponent: () => import('./components/users/user-form').then(m => m.UserFormComponent) },
+      { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
+      { path: '**', redirectTo: 'dashboard' }
+    ]
   }
 ];

--- a/frontend/src/app/components/dashboard/dashboard.html
+++ b/frontend/src/app/components/dashboard/dashboard.html
@@ -1,209 +1,157 @@
-<div class="min-h-screen bg-gray-50">
-  <!-- Header -->
-  <header class="bg-white shadow-sm border-b border-gray-200">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="flex justify-between items-center h-16">
-        <!-- Logo/Title -->
-        <div class="flex items-center">
-          <div class="flex-shrink-0">
-            <h1 class="text-xl font-bold text-gray-900">
-              <i class="pi pi-chart-line mr-2 text-primary-600"></i>
-              Dashboard
-            </h1>
-          </div>
+<main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <!-- Welcome Section -->
+  <div class="mb-8">
+    <h2 class="text-2xl font-bold text-gray-900 mb-2">
+      Bem-vindo, {{ currentUser?.fullName || currentUser?.username }}! 👋
+    </h2>
+    <p class="text-gray-600">Aqui está um resumo das suas atividades e estatísticas do sistema.</p>
+  </div>
+
+  <!-- Stats Cards -->
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+    <p-card *ngFor="let stat of statsCards" styleClass="border border-gray-200 rounded-xl">
+      <div class="flex items-center justify-between p-6">
+        <div>
+          <p class="text-sm font-medium text-gray-600">{{ stat.title }}</p>
+          <p class="text-2xl font-bold text-gray-900">{{ stat.value }}</p>
+          <p class="text-xs text-gray-500 mt-1">{{ stat.subtitle }}</p>
         </div>
-
-        <!-- User Menu -->
-        <div class="flex items-center space-x-4">
-          <div class="text-right hidden sm:block">
-            <p class="text-sm font-medium text-gray-900">{{ currentUser?.fullName || currentUser?.username }}</p>
-            <p class="text-xs text-gray-500">{{ currentUser?.email }}</p>
-          </div>
-
-          <p-avatar
-            [label]="getUserInitials()"
-            styleClass="bg-primary-600 text-white"
-            size="normal"
-            shape="circle"
-          ></p-avatar>
-
-          <p-button
-            label="Usuários"
-            icon="pi pi-users"
-            [text]="true"
-            (onClick)="goUsers()"
-          ></p-button>
-
-          <p-button
-            icon="pi pi-sign-out"
-            [text]="true"
-            severity="secondary"
-            (onClick)="logout()"
-            pTooltip="Sair"
-            tooltipPosition="bottom"
-          ></p-button>
+        <div class="p-3 rounded-full" [ngClass]="stat.iconBg">
+          <i [class]="stat.icon + ' text-xl'"></i>
         </div>
       </div>
-    </div>
-  </header>
+    </p-card>
+  </div>
 
-  <!-- Main Content -->
-  <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Welcome Section -->
-    <div class="mb-8">
-      <h2 class="text-2xl font-bold text-gray-900 mb-2">
-        Bem-vindo, {{ currentUser?.fullName || currentUser?.username }}! 👋
-      </h2>
-      <p class="text-gray-600">Aqui está um resumo das suas atividades e estatísticas do sistema.</p>
-    </div>
-
-    <!-- Stats Cards -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-      <p-card *ngFor="let stat of statsCards" styleClass="border border-gray-200 rounded-xl">
-        <div class="flex items-center justify-between p-6">
-          <div>
-            <p class="text-sm font-medium text-gray-600">{{ stat.title }}</p>
-            <p class="text-2xl font-bold text-gray-900">{{ stat.value }}</p>
-            <p class="text-xs text-gray-500 mt-1">{{ stat.subtitle }}</p>
-          </div>
-          <div class="p-3 rounded-full" [ngClass]="stat.iconBg">
-            <i [class]="stat.icon + ' text-xl'"></i>
-          </div>
-        </div>
-      </p-card>
-    </div>
-
-    <!-- Charts and Data Section -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-      <!-- System Performance -->
-      <p-card styleClass="h-full border border-gray-200 rounded-xl">
-        <ng-template pTemplate="header">
-          <div class="bg-gray-50 border-b border-gray-200 px-6 py-4 font-semibold text-gray-700">Performance do Sistema</div>
-        </ng-template>
-        <ng-template pTemplate="content">
-          <div class="space-y-4 p-6">
-            <div>
-              <div class="flex justify-between items-center mb-2">
-                <span class="text-sm font-medium text-gray-700">CPU</span>
-                <span class="text-sm text-gray-500">{{ dashboardData?.charts?.systemPerformance?.cpu || 0 }}%</span>
-              </div>
-              <p-progressBar
-                [value]="dashboardData?.charts?.systemPerformance?.cpu || 0"
-                [style]="{'height': '8px'}"
-                styleClass="bg-gray-200 rounded-md"
-              ></p-progressBar>
-            </div>
-
-            <div>
-              <div class="flex justify-between items-center mb-2">
-                <span class="text-sm font-medium text-gray-700">Memória</span>
-                <span class="text-sm text-gray-500">{{ dashboardData?.charts?.systemPerformance?.memory || 0 }}%</span>
-              </div>
-              <p-progressBar
-                [value]="dashboardData?.charts?.systemPerformance?.memory || 0"
-                [style]="{'height': '8px'}"
-                styleClass="bg-gray-200 rounded-md"
-                severity="warning"
-              ></p-progressBar>
-            </div>
-
-            <div>
-              <div class="flex justify-between items-center mb-2">
-                <span class="text-sm font-medium text-gray-700">Disco</span>
-                <span class="text-sm text-gray-500">{{ dashboardData?.charts?.systemPerformance?.disk || 0 }}%</span>
-              </div>
-              <p-progressBar
-                [value]="dashboardData?.charts?.systemPerformance?.disk || 0"
-                [style]="{'height': '8px'}"
-                styleClass="bg-gray-200 rounded-md"
-                severity="success"
-              ></p-progressBar>
-            </div>
-          </div>
-        </ng-template>
-      </p-card>
-
-      <!-- Notifications -->
-      <p-card styleClass="h-full border border-gray-200 rounded-xl">
-        <ng-template pTemplate="header">
-          <div class="bg-gray-50 border-b border-gray-200 px-6 py-4 font-semibold text-gray-700">Notificações</div>
-        </ng-template>
-        <ng-template pTemplate="content">
-          <div class="space-y-3 p-6">
-            <div *ngFor="let notification of dashboardData?.notifications"
-                 class="flex items-start space-x-3 p-3 rounded-lg border"
-                 [ngClass]="{
-                   'bg-blue-50 border-blue-200': notification.type === 'info',
-                   'bg-green-50 border-green-200': notification.type === 'success',
-                   'bg-yellow-50 border-yellow-200': notification.type === 'warning',
-                   'bg-red-50 border-red-200': notification.type === 'error'
-                 }">
-              <i [class]="getNotificationIcon(notification.type)"
-                 [ngClass]="{
-                   'text-blue-600': notification.type === 'info',
-                   'text-green-600': notification.type === 'success',
-                   'text-yellow-600': notification.type === 'warning',
-                   'text-red-600': notification.type === 'error'
-                 }"></i>
-              <div class="flex-1 min-w-0">
-                <p class="text-sm font-medium text-gray-900">{{ notification.title }}</p>
-                <p class="text-xs text-gray-600">{{ notification.message }}</p>
-                <p class="text-xs text-gray-400 mt-1">{{ formatDate(notification.timestamp) }}</p>
-              </div>
-            </div>
-          </div>
-        </ng-template>
-      </p-card>
-    </div>
-
-    <!-- Recent Activity Table -->
-    <p-card styleClass="border border-gray-200 rounded-xl">
+  <!-- Charts and Data Section -->
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+    <!-- System Performance -->
+    <p-card styleClass="h-full border border-gray-200 rounded-xl">
       <ng-template pTemplate="header">
-        <div class="bg-gray-50 border-b border-gray-200 px-6 py-4 font-semibold text-gray-700">Atividade Recente</div>
+        <div class="bg-gray-50 border-b border-gray-200 px-6 py-4 font-semibold text-gray-700">Performance do Sistema</div>
       </ng-template>
       <ng-template pTemplate="content">
-        <p-table
-          [value]="dashboardData?.recentActivity || []"
-          [loading]="isLoading"
-          styleClass="w-full"
-          tableStyleClass="w-full"
-        >
-          <ng-template pTemplate="header">
-            <tr>
-              <th class="bg-gray-50 border border-gray-200 text-gray-700 font-semibold p-4">ID</th>
-              <th class="bg-gray-50 border border-gray-200 text-gray-700 font-semibold p-4">Ação</th>
-              <th class="bg-gray-50 border border-gray-200 text-gray-700 font-semibold p-4">Usuário</th>
-              <th class="bg-gray-50 border border-gray-200 text-gray-700 font-semibold p-4">Data/Hora</th>
-              <th class="bg-gray-50 border border-gray-200 text-gray-700 font-semibold p-4">Status</th>
-            </tr>
-          </ng-template>
-          <ng-template pTemplate="body" let-activity>
-            <tr>
-              <td class="border border-gray-200 p-4">{{ activity.id }}</td>
-              <td class="border border-gray-200 p-4">
-                <i class="pi pi-check-circle text-green-600 mr-2"></i>
-                {{ activity.action }}
-              </td>
-              <td class="border border-gray-200 p-4">{{ activity.user }}</td>
-              <td class="border border-gray-200 p-4">{{ formatDate(activity.timestamp) }}</td>
-              <td class="border border-gray-200 p-4">
-                <p-tag value="Sucesso" severity="success" styleClass="rounded-md font-medium"></p-tag>
-              </td>
-            </tr>
-          </ng-template>
-          <ng-template pTemplate="emptymessage">
-            <tr>
-              <td colspan="5" class="text-center py-8 text-gray-500">
-                <i class="pi pi-info-circle mr-2"></i>
-                Nenhuma atividade encontrada
-              </td>
-            </tr>
-          </ng-template>
-        </p-table>
+        <div class="space-y-4 p-6">
+          <div>
+            <div class="flex justify-between items-center mb-2">
+              <span class="text-sm font-medium text-gray-700">CPU</span>
+              <span class="text-sm text-gray-500">{{ dashboardData?.charts?.systemPerformance?.cpu || 0 }}%</span>
+            </div>
+            <p-progressBar
+              [value]="dashboardData?.charts?.systemPerformance?.cpu || 0"
+              [style]="{'height': '8px'}"
+              styleClass="bg-gray-200 rounded-md"
+            ></p-progressBar>
+          </div>
+
+          <div>
+            <div class="flex justify-between items-center mb-2">
+              <span class="text-sm font-medium text-gray-700">Memória</span>
+              <span class="text-sm text-gray-500">{{ dashboardData?.charts?.systemPerformance?.memory || 0 }}%</span>
+            </div>
+            <p-progressBar
+              [value]="dashboardData?.charts?.systemPerformance?.memory || 0"
+              [style]="{'height': '8px'}"
+              styleClass="bg-gray-200 rounded-md"
+              severity="warning"
+            ></p-progressBar>
+          </div>
+
+          <div>
+            <div class="flex justify-between items-center mb-2">
+              <span class="text-sm font-medium text-gray-700">Disco</span>
+              <span class="text-sm text-gray-500">{{ dashboardData?.charts?.systemPerformance?.disk || 0 }}%</span>
+            </div>
+            <p-progressBar
+              [value]="dashboardData?.charts?.systemPerformance?.disk || 0"
+              [style]="{'height': '8px'}"
+              styleClass="bg-gray-200 rounded-md"
+              severity="success"
+            ></p-progressBar>
+          </div>
+        </div>
       </ng-template>
     </p-card>
-  </main>
-</div>
 
-<!-- Toast para notificações -->
+    <!-- Notifications -->
+    <p-card styleClass="h-full border border-gray-200 rounded-xl">
+      <ng-template pTemplate="header">
+        <div class="bg-gray-50 border-b border-gray-200 px-6 py-4 font-semibold text-gray-700">Notificações</div>
+      </ng-template>
+      <ng-template pTemplate="content">
+        <div class="space-y-3 p-6">
+          <div *ngFor="let notification of dashboardData?.notifications"
+               class="flex items-start space-x-3 p-3 rounded-lg border"
+               [ngClass]="{
+                 'bg-blue-50 border-blue-200': notification.type === 'info',
+                 'bg-green-50 border-green-200': notification.type === 'success',
+                 'bg-yellow-50 border-yellow-200': notification.type === 'warning',
+                 'bg-red-50 border-red-200': notification.type === 'error'
+               }">
+            <i [class]="getNotificationIcon(notification.type)"
+               [ngClass]="{
+                 'text-blue-600': notification.type === 'info',
+                 'text-green-600': notification.type === 'success',
+                 'text-yellow-600': notification.type === 'warning',
+                 'text-red-600': notification.type === 'error'
+               }"></i>
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-medium text-gray-900">{{ notification.title }}</p>
+              <p class="text-xs text-gray-600">{{ notification.message }}</p>
+              <p class="text-xs text-gray-400 mt-1">{{ formatDate(notification.timestamp) }}</p>
+            </div>
+          </div>
+        </div>
+      </ng-template>
+    </p-card>
+  </div>
+
+  <!-- Recent Activity Table -->
+  <p-card styleClass="border border-gray-200 rounded-xl">
+    <ng-template pTemplate="header">
+      <div class="bg-gray-50 border-b border-gray-200 px-6 py-4 font-semibold text-gray-700">Atividade Recente</div>
+    </ng-template>
+    <ng-template pTemplate="content">
+      <p-table
+        [value]="dashboardData?.recentActivity || []"
+        [loading]="isLoading"
+        styleClass="w-full"
+        tableStyleClass="w-full"
+      >
+        <ng-template pTemplate="header">
+          <tr>
+            <th class="bg-gray-50 border border-gray-200 text-gray-700 font-semibold p-4">ID</th>
+            <th class="bg-gray-50 border border-gray-200 text-gray-700 font-semibold p-4">Ação</th>
+            <th class="bg-gray-50 border border-gray-200 text-gray-700 font-semibold p-4">Usuário</th>
+            <th class="bg-gray-50 border border-gray-200 text-gray-700 font-semibold p-4">Data/Hora</th>
+            <th class="bg-gray-50 border border-gray-200 text-gray-700 font-semibold p-4">Status</th>
+          </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-activity>
+          <tr>
+            <td class="border border-gray-200 p-4">{{ activity.id }}</td>
+            <td class="border border-gray-200 p-4">
+              <i class="pi pi-check-circle text-green-600 mr-2"></i>
+              {{ activity.action }}
+            </td>
+            <td class="border border-gray-200 p-4">{{ activity.user }}</td>
+            <td class="border border-gray-200 p-4">{{ formatDate(activity.timestamp) }}</td>
+            <td class="border border-gray-200 p-4">
+              <p-tag value="Sucesso" severity="success" styleClass="rounded-md font-medium"></p-tag>
+            </td>
+          </tr>
+        </ng-template>
+        <ng-template pTemplate="emptymessage">
+          <tr>
+            <td colspan="5" class="text-center py-8 text-gray-500">
+              <i class="pi pi-info-circle mr-2"></i>
+              Nenhuma atividade encontrada
+            </td>
+          </tr>
+        </ng-template>
+      </p-table>
+    </ng-template>
+  </p-card>
+</main>
+
 <p-toast></p-toast>

--- a/frontend/src/app/components/dashboard/dashboard.ts
+++ b/frontend/src/app/components/dashboard/dashboard.ts
@@ -5,20 +5,15 @@
 
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Router } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 
 // PrimeNG imports
 import { CardModule } from 'primeng/card';
-import { ButtonModule } from 'primeng/button';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
-import { AvatarModule } from 'primeng/avatar';
-import { MenuModule } from 'primeng/menu';
-import { MenuItem } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
 
 import { AuthService, User } from '../../services/auth';
@@ -30,13 +25,10 @@ import { ApiService } from '../../services/api';
   imports: [
     CommonModule,
     CardModule,
-    ButtonModule,
     TableModule,
     TagModule,
     ProgressBarModule,
     ToastModule,
-    AvatarModule,
-    MenuModule,
     SkeletonModule
   ],
   providers: [MessageService],
@@ -47,31 +39,27 @@ export class DashboardComponent implements OnInit, OnDestroy {
   dashboardData: any = null;
   isLoading = true;
   statsCards: any[] = [];
-  
+
   private destroy$ = new Subject<void>();
 
   constructor(
     private authService: AuthService,
     private apiService: ApiService,
-    private router: Router,
     private messageService: MessageService
   ) {}
 
   ngOnInit(): void {
     // Obter usuário atual
     this.currentUser = this.authService.getCurrentUser();
-    
+
     // Carregar dados do dashboard
     this.loadDashboardData();
-    
+
     // Escutar mudanças no estado de autenticação
     this.authService.authState$
       .pipe(takeUntil(this.destroy$))
       .subscribe(state => {
         this.currentUser = state.user;
-        if (!state.isAuthenticated) {
-          this.router.navigate(['/login']);
-        }
       });
   }
 
@@ -82,13 +70,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   loadDashboardData(): void {
     this.isLoading = true;
-    
+
     this.apiService.getDashboardData().subscribe({
       next: (response) => {
         this.dashboardData = response.data;
         this.setupStatsCards();
         this.isLoading = false;
-        
+
         this.messageService.add({
           severity: 'success',
           summary: 'Dashboard carregado',
@@ -98,7 +86,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       error: (error) => {
         this.isLoading = false;
         console.error('Erro ao carregar dashboard:', error);
-        
+
         this.messageService.add({
           severity: 'error',
           summary: 'Erro',
@@ -110,7 +98,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   setupStatsCards(): void {
     if (!this.dashboardData?.stats) return;
-    
+
     this.statsCards = [
       {
         title: 'Usuários Totais',
@@ -124,36 +112,23 @@ export class DashboardComponent implements OnInit, OnDestroy {
         value: this.dashboardData.stats.activeUsers,
         subtitle: 'Online agora',
         icon: 'pi pi-user-plus',
-        iconBg: 'bg-green-100 text-green-600'
+        iconBg: 'bg-green-100 text-green-600',
       },
       {
         title: 'Sessões',
         value: this.dashboardData.stats.totalSessions,
         subtitle: 'Sessões ativas',
         icon: 'pi pi-desktop',
-        iconBg: 'bg-yellow-100 text-yellow-600'
+        iconBg: 'bg-yellow-100 text-yellow-600',
       },
       {
         title: 'Uptime',
         value: this.formatUptime(this.dashboardData.stats.serverUptime),
         subtitle: 'Tempo online',
         icon: 'pi pi-clock',
-        iconBg: 'bg-purple-100 text-purple-600'
+        iconBg: 'bg-purple-100 text-purple-600',
       }
     ];
-  }
-
-  getUserInitials(): string {
-    if (!this.currentUser) return 'U';
-    
-    const name = this.currentUser.fullName || this.currentUser.username;
-    const parts = name.split(' ');
-    
-    if (parts.length >= 2) {
-      return (parts[0][0] + parts[1][0]).toUpperCase();
-    }
-    
-    return name.substring(0, 2).toUpperCase();
   }
 
   getNotificationIcon(type: string): string {
@@ -174,30 +149,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
   formatUptime(seconds: number): string {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
-    
+
     if (hours > 0) {
       return `${hours}h ${minutes}m`;
     }
-    
+
     return `${minutes}m`;
-  }
-
-  logout(): void {
-    this.authService.logout().subscribe({
-      next: () => {
-        this.messageService.add({
-          severity: 'success',
-          summary: 'Logout realizado',
-          detail: 'Até logo!'
-        });
-      },
-      error: (error) => {
-        console.error('Erro no logout:', error);
-      }
-    });
-  }
-
-  goUsers(): void {
-    this.router.navigate(['/users']);
   }
 }

--- a/frontend/src/app/components/layout/master-layout.html
+++ b/frontend/src/app/components/layout/master-layout.html
@@ -1,0 +1,25 @@
+<div class="layout-topbar">
+  <div class="layout-logo">
+    <a routerLink="/dashboard">Tematico</a>
+  </div>
+  <div class="layout-topbar-actions">
+    <span class="user-name">{{ currentUser?.fullName || currentUser?.username }}</span>
+    <p-avatar [label]="getUserInitials()" styleClass="bg-primary-600 text-white" size="normal" shape="circle"></p-avatar>
+    <p-button icon="pi pi-sign-out" [text]="true" severity="secondary" (onClick)="logout()"></p-button>
+  </div>
+</div>
+
+<div class="layout-sidebar">
+  <nav>
+    <a routerLink="/dashboard" routerLinkActive="active">Dashboard</a>
+    <a routerLink="/users" routerLinkActive="active">Usuários</a>
+  </nav>
+</div>
+
+<div class="layout-main">
+  <router-outlet />
+</div>
+
+<div class="layout-footer">
+  <span>© 2024 Tematico</span>
+</div>

--- a/frontend/src/app/components/layout/master-layout.scss
+++ b/frontend/src/app/components/layout/master-layout.scss
@@ -1,0 +1,61 @@
+.layout-topbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 2rem;
+  background: var(--surface-card);
+  border-bottom: 1px solid var(--surface-border);
+  z-index: 1000;
+}
+
+.layout-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.layout-sidebar {
+  position: fixed;
+  top: 4rem;
+  left: 0;
+  bottom: 0;
+  width: 220px;
+  background: var(--surface-overlay);
+  border-right: 1px solid var(--surface-border);
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.layout-sidebar a {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 0.5rem;
+}
+
+.layout-sidebar a.active,
+.layout-sidebar a:hover {
+  background: var(--primary-100, #dbeafe);
+  color: var(--primary-color, #3b82f6);
+}
+
+.layout-main {
+  margin-top: 4rem;
+  margin-left: 220px;
+  padding: 2rem;
+  min-height: calc(100vh - 4rem - 3rem);
+  background: var(--surface-ground);
+}
+
+.layout-footer {
+  margin-left: 220px;
+  padding: 1rem 2rem;
+  background: var(--surface-card);
+  border-top: 1px solid var(--surface-border);
+}

--- a/frontend/src/app/components/layout/master-layout.ts
+++ b/frontend/src/app/components/layout/master-layout.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { Subject, takeUntil } from 'rxjs';
+import { ButtonModule } from 'primeng/button';
+import { AvatarModule } from 'primeng/avatar';
+
+import { AuthService, User } from '../../services/auth';
+
+@Component({
+  selector: 'app-master-layout',
+  standalone: true,
+  imports: [CommonModule, RouterModule, ButtonModule, AvatarModule],
+  templateUrl: './master-layout.html',
+  styleUrls: ['./master-layout.scss'],
+})
+export class MasterLayoutComponent implements OnInit, OnDestroy {
+  currentUser: User | null = null;
+  private destroy$ = new Subject<void>();
+
+  constructor(private authService: AuthService) {}
+
+  ngOnInit(): void {
+    this.currentUser = this.authService.getCurrentUser();
+    this.authService.authState$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(state => {
+        this.currentUser = state.user;
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  getUserInitials(): string {
+    if (!this.currentUser) return 'U';
+    const name = this.currentUser.fullName || this.currentUser.username;
+    const parts = name.split(' ');
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[1][0]).toUpperCase();
+    }
+    return name.substring(0, 2).toUpperCase();
+  }
+
+  logout(): void {
+    this.authService.logout().subscribe();
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone master layout with topbar, sidebar and footer
- route protected pages through master layout
- streamline dashboard component content

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68941d039100832e8fafb73e80be1a00