### PR TITLE
refactor: use CSS variables for color palette

### DIFF
--- a/frontend/src/app/components/layout/master-layout.scss
+++ b/frontend/src/app/components/layout/master-layout.scss
@@ -41,8 +41,8 @@
 
 .layout-sidebar a.active,
 .layout-sidebar a:hover {
-  background: var(--primary-100, #dbeafe);
-  color: var(--primary-color, #3b82f6);
+  background: var(--primary-100);
+  color: var(--primary-color);
 }
 
 .layout-main {

--- a/frontend/src/app/components/login/login.scss
+++ b/frontend/src/app/components/login/login.scss
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(to bottom right, #eff6ff, #e0e7ff);
+  background: linear-gradient(to bottom right, var(--surface-100), var(--surface-200));
   padding: 1rem;
 }
 
@@ -24,24 +24,24 @@
   width: 4rem;
   height: 4rem;
   border-radius: 50%;
-  background: #4f46e5;
+  background: var(--primary-color);
   margin: 0 auto 1rem;
 }
 
 .logo-circle i {
-  color: #fff;
+  color: var(--surface-0);
   font-size: 2rem;
 }
 
 .logo h1 {
   font-size: 1.875rem;
   font-weight: 700;
-  color: #111827;
+  color: var(--color-text-primary);
   margin-bottom: 0.5rem;
 }
 
 .logo p {
-  color: #4b5563;
+  color: var(--color-text-muted);
 }
 
 .login-card .card-content {
@@ -58,7 +58,7 @@
   display: block;
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-text-secondary);
   margin-bottom: 0.25rem;
 }
 
@@ -66,8 +66,8 @@
   display: block;
   border: 0;
   padding: 0.5rem 1rem;
-  background: #fee2e2;
-  color: #b91c1c;
+  background: var(--color-error-bg);
+  color: var(--color-error-text);
 }
 
 .forgot-link {
@@ -75,32 +75,32 @@
   text-align: center;
   margin-top: 1rem;
   font-size: 0.875rem;
-  color: #2563eb;
+  color: var(--color-link);
 }
 
 .info-box {
   margin-top: 1.5rem;
   padding: 1rem;
   border-radius: 0.5rem;
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
+  background: var(--surface-100);
+  border: 1px solid var(--color-border);
 }
 
 .info-box h3 {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #1e40af;
+  color: var(--color-link-dark);
   margin-bottom: 0.5rem;
 }
 
 .info-box .credentials {
   font-size: 0.875rem;
-  color: #1e3a8a;
+  color: var(--color-link-darker);
 }
 
 .footer {
   text-align: center;
   margin-top: 2rem;
   font-size: 0.875rem;
-  color: #6b7280;
+  color: var(--color-text-disabled);
 }

--- a/frontend/src/app/components/reset-password/reset-password.scss
+++ b/frontend/src/app/components/reset-password/reset-password.scss
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f3f4f6;
+  background: var(--surface-300);
   padding: 1rem;
 }
 
@@ -28,6 +28,6 @@ label {
   display: block;
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-text-secondary);
   margin-bottom: 0.5rem;
 }

--- a/frontend/src/app/components/users/user-form.scss
+++ b/frontend/src/app/components/users/user-form.scss
@@ -23,6 +23,6 @@ label {
   display: block;
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-text-secondary);
   margin-bottom: 0.5rem;
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,3 +1,33 @@
+:root {
+  --color-primary: #295785;
+  --color-secondary: #41729F;
+  --color-primary-100: #DBEAFE;
+  --color-surface-0: #FFFFFF;
+  --color-surface-50: #F4F8FB;
+  --color-surface-100: #EFF6FF;
+  --color-surface-200: #E0E7FF;
+  --color-surface-300: #F3F4F6;
+  --color-text-primary: #111827;
+  --color-text-muted: #4B5563;
+  --color-text-secondary: #374151;
+  --color-text-disabled: #6B7280;
+  --color-error-bg: #FEE2E2;
+  --color-error-text: #B91C1C;
+  --color-link: #2563EB;
+  --color-link-dark: #1E40AF;
+  --color-link-darker: #1E3A8A;
+  --color-border: #BFDBFE;
+
+  /* PrimeNG token mappings */
+  --primary-color: var(--color-primary);
+  --primary-100: var(--color-primary-100);
+  --surface-0: var(--color-surface-0);
+  --surface-50: var(--color-surface-50);
+  --surface-100: var(--color-surface-100);
+  --surface-200: var(--color-surface-200);
+  --surface-300: var(--color-surface-300);
+}
+
 body {
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- centralize theme colors via CSS variables and PrimeNG token mappings
- replace hard-coded hex colors with palette variables in login, reset-password, user form and layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894b4c21f60832e84146f99de965b53