### PR TITLE
refactor: remove full_name fallback in user list

### DIFF
--- a/frontend/src/app/components/users/user-list.html
+++ b/frontend/src/app/components/users/user-list.html
@@ -17,7 +17,7 @@
       <tr>
         <td>{{ user.username }}</td>
         <td>{{ user.email }}</td>
-        <td>{{ user.full_name || user.fullName }}</td>
+        <td>{{ user.fullName }}</td>
         <td>
           <p-button icon="pi pi-pencil" [rounded]="true" [text]="true" (onClick)="editUser(user.id)"></p-button>
           <p-button icon="pi pi-trash" [rounded]="true" [text]="true" severity="danger" (onClick)="deleteUser(user.id)"></p-button>


### PR DESCRIPTION
## Summary
- clean up user list template to rely solely on `user.fullName`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build:frontend`


------
https://chatgpt.com/codex/tasks/task_e_6894f4650298832ea4f60b09a043c43a