### PR TITLE
Rename full_name field to fullName in user routes

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -12,7 +12,8 @@ router.get('/', (req, res) => {
       console.error('❌ Erro ao listar usuários:', err.message);
       return res.status(500).json({ error: 'Erro ao listar usuários' });
     }
-    res.json(rows);
+    const formattedRows = rows.map(({ full_name, ...rest }) => ({ ...rest, fullName: full_name }));
+    res.json(formattedRows);
   });
 });
 
@@ -27,7 +28,8 @@ router.get('/:id', (req, res) => {
     if (!row) {
       return res.status(404).json({ error: 'Usuário não encontrado' });
     }
-    res.json(row);
+    const { full_name, ...rest } = row;
+    res.json({ ...rest, fullName: full_name });
   });
 });
 


### PR DESCRIPTION
## Summary
- rename `full_name` to `fullName` in user listing and retrieval routes

## Testing
- `node backend/server.js` *(fails: connect ECONNREFUSED ::1:5432)*
- `node - <<'NODE' ...` (mocked database verifying `fullName` field)


------
https://chatgpt.com/codex/tasks/task_e_6894f4657e3c832ebb3bedd7927bcb42