### PR TITLE
Refactor user service mapping

### DIFF
--- a/frontend/src/app/services/users.ts
+++ b/frontend/src/app/services/users.ts
@@ -27,15 +27,11 @@ export class UserService {
 
   getUsers(): Observable<AppUser[]> {
     return this.http.get<any[]>(`${this.API_URL}/users`).pipe(
-      map(users =>
-        users.map(user => ({
-          id: user.id,
-          username: user.username,
-          email: user.email,
-          fullName: user.full_name,
-          is_active: user.is_active,
-        }))
-        users.map(({ full_name, ...user }) => ({ ...user, fullName: full_name }) as AppUser)
+      map((users: any[]) =>
+        users.map(({ full_name, ...user }: any) => ({
+          ...user,
+          fullName: full_name,
+        }) as AppUser)
       ),
       catchError(error => {
         console.error('❌ Erro ao listar usuários:', error);
@@ -46,14 +42,10 @@ export class UserService {
 
   getUser(id: number): Observable<AppUser> {
     return this.http.get<any>(`${this.API_URL}/users/${id}`).pipe(
-      map(user => ({
-        id: user.id,
-        username: user.username,
-        email: user.email,
-        fullName: user.full_name,
-        is_active: user.is_active,
-      })),
-      map(({ full_name, ...user }) => ({ ...user, fullName: full_name }) as AppUser),
+      map(({ full_name, ...user }: any) => ({
+        ...user,
+        fullName: full_name,
+      }) as AppUser),
       catchError(error => {
         console.error('❌ Erro ao obter usuário:', error);
         return throwError(() => error);


### PR DESCRIPTION
## Summary
- simplify conversion of API users to AppUser
- clean up getUser logic and remove redundant map calls

## Testing
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894f7b8025c832e97a11eef27d3fada