### PR TITLE
feat: centralize backend error handling

### DIFF
--- a/backend/middleware/errorHandler.js
+++ b/backend/middleware/errorHandler.js
@@ -1,0 +1,28 @@
+class ApiError extends Error {
+  constructor(statusCode, message, code, details) {
+    super(message);
+    this.statusCode = statusCode;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function errorHandler(err, req, res, next) {
+  console.error('❌', err.message, err.details || err.stack);
+
+  if (err.name === 'JsonWebTokenError') {
+    return res.status(401).json({ error: 'Token inválido', code: 'TOKEN_INVALID' });
+  }
+  if (err.name === 'TokenExpiredError') {
+    return res.status(401).json({ error: 'Token expirado', code: 'TOKEN_EXPIRED' });
+  }
+
+  const status = err.statusCode || 500;
+  const response = { error: err.message || 'Erro interno do servidor' };
+  if (err.code) response.code = err.code;
+  if (err.details) response.details = err.details;
+
+  res.status(status).json(response);
+}
+
+module.exports = { ApiError, errorHandler };

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,7 @@ const rateLimit = require('express-rate-limit');
 const path = require('path');
 const swaggerUi = require('swagger-ui-express');
 const swaggerDocument = require('./swagger.json');
+const { ApiError, errorHandler } = require('./middleware/errorHandler');
 
 // Importar rotas
 const authRoutes = require('./routes/auth');
@@ -94,35 +95,11 @@ app.use('/users', authenticateToken, usersRoutes);
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 // Middleware de tratamento de erros
-app.use((err, req, res, next) => {
-  console.error('Erro:', err.stack);
-  
-  // Erro de validação JWT
-  if (err.name === 'JsonWebTokenError') {
-    return res.status(401).json({
-      error: 'Token inválido'
-    });
-  }
-  
-  // Erro de token expirado
-  if (err.name === 'TokenExpiredError') {
-    return res.status(401).json({
-      error: 'Token expirado'
-    });
-  }
-  
-  // Erro genérico
-  res.status(500).json({
-    error: 'Erro interno do servidor'
-  });
+app.use((req, res, next) => {
+  next(new ApiError(404, 'Rota não encontrada'));
 });
 
-// Rota 404 - não encontrada
-app.use('*', (req, res) => {
-  res.status(404).json({
-    error: 'Rota não encontrada'
-  });
-});
+app.use(errorHandler);
 
 // Inicializar banco de dados e servidor
 async function startServer() {


### PR DESCRIPTION
## Summary
- add centralized error handler middleware and wire it into server
- standardize route error responses and sanitize boolean comparisons
- improve authentication middleware and dashboard/user endpoints

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6894fbdf1b84832eaa64a642b4dae82d