### PR TITLE
Add user menu with password change option

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -30,6 +30,7 @@ export const routes: Routes = [
       { path: 'users', loadComponent: () => import('./components/users/user-list').then(m => m.UserListComponent) },
       { path: 'users/new', loadComponent: () => import('./components/users/user-form').then(m => m.UserFormComponent) },
       { path: 'users/:id', loadComponent: () => import('./components/users/user-form').then(m => m.UserFormComponent) },
+      { path: 'change-password', loadComponent: () => import('./components/change-password/change-password').then(m => m.ChangePasswordComponent) },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: '**', redirectTo: 'dashboard' }
     ]

--- a/frontend/src/app/components/change-password/change-password.html
+++ b/frontend/src/app/components/change-password/change-password.html
@@ -1,0 +1,14 @@
+<div class="change-password">
+  <p-toast></p-toast>
+  <p-card class="form-card">
+    <h2 class="title">Trocar Senha</h2>
+    <form (ngSubmit)="onSubmit()" #f="ngForm" class="form">
+      <div>
+        <label for="password">Nova Senha</label>
+        <p-password [(ngModel)]="password" name="password" required [feedback]="false" placeholder="Nova senha" styleClass="w-full" inputStyleClass="w-full"></p-password>
+      </div>
+      <p-button type="submit" label="Salvar" [disabled]="!f.valid || isLoading" [loading]="isLoading" styleClass="w-full"></p-button>
+    </form>
+  </p-card>
+</div>
+

--- a/frontend/src/app/components/change-password/change-password.scss
+++ b/frontend/src/app/components/change-password/change-password.scss
@@ -1,0 +1,34 @@
+.change-password {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-300);
+  padding: 1rem;
+}
+
+.form-card {
+  width: 100%;
+  max-width: 28rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  margin-bottom: 0.5rem;
+}
+

--- a/frontend/src/app/components/change-password/change-password.ts
+++ b/frontend/src/app/components/change-password/change-password.ts
@@ -1,0 +1,45 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { CardModule } from 'primeng/card';
+import { PasswordModule } from 'primeng/password';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+import { AuthService } from '../../services/auth';
+
+@Component({
+  selector: 'app-change-password',
+  standalone: true,
+  imports: [CommonModule, FormsModule, CardModule, PasswordModule, ButtonModule, ToastModule],
+  providers: [MessageService],
+  templateUrl: './change-password.html',
+  styleUrls: ['./change-password.scss']
+})
+export class ChangePasswordComponent {
+  password = '';
+  isLoading = false;
+
+  constructor(private authService: AuthService, private router: Router, private messageService: MessageService) {}
+
+  onSubmit(): void {
+    const user = this.authService.getCurrentUser();
+    if (!user?.email || !this.password) { return; }
+    this.isLoading = true;
+    this.authService.resetPassword(user.email, this.password).subscribe({
+      next: () => {
+        this.isLoading = false;
+        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Senha alterada com sucesso' });
+        setTimeout(() => this.router.navigate(['/dashboard']), 1000);
+      },
+      error: (err) => {
+        this.isLoading = false;
+        let msg = 'Erro ao trocar senha';
+        if (err.error?.error) { msg = err.error.error; }
+        this.messageService.add({ severity: 'error', summary: 'Erro', detail: msg });
+      }
+    });
+  }
+}
+

--- a/frontend/src/app/components/layout/component/app.topbar.ts
+++ b/frontend/src/app/components/layout/component/app.topbar.ts
@@ -1,14 +1,16 @@
 import { Component } from '@angular/core';
 import { MenuItem } from 'primeng/api';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { StyleClassModule } from 'primeng/styleclass';
+import { MenuModule } from 'primeng/menu';
 import { LayoutService } from '../service/layout.service';
+import { AuthService, User } from '../../../services/auth';
 
 @Component({
     selector: 'app-topbar',
     standalone: true,
-    imports: [RouterModule, CommonModule, StyleClassModule],
+    imports: [RouterModule, CommonModule, StyleClassModule, MenuModule],
     template: ` <div class="layout-topbar">
         <div class="layout-topbar-logo-container">
             <button class="layout-menu-button layout-topbar-action" (click)="layoutService.onMenuToggle()">
@@ -28,21 +30,43 @@ import { LayoutService } from '../service/layout.service';
 
             <div class="layout-topbar-menu hidden lg:block">
                 <div class="layout-topbar-menu-content">
-                    <button type="button" class="layout-topbar-action">
+                    <button type="button" class="layout-topbar-action" (click)="userMenu.toggle($event)">
                         <i class="pi pi-user"></i>
-                        <span>Profile</span>
                     </button>
+                    <p-menu #userMenu [model]="menuItems" [popup]="true" styleClass="user-menu">
+                        <ng-template pTemplate="start">
+                            <div class="p-2">
+                                <div class="font-bold">{{ user?.fullName }}</div>
+                                <div class="text-sm text-color-secondary">{{ user?.username }}</div>
+                            </div>
+                        </ng-template>
+                    </p-menu>
                 </div>
             </div>
         </div>
     </div>`
 })
 export class AppTopbar {
-    items!: MenuItem[];
+    menuItems!: MenuItem[];
+    user: User | null;
 
-    constructor(public layoutService: LayoutService) {}
+    constructor(public layoutService: LayoutService, private authService: AuthService, private router: Router) {
+        this.user = this.authService.getCurrentUser();
+        this.menuItems = [
+            { label: 'Trocar senha', command: () => this.onChangePassword() },
+            { label: 'Logout', command: () => this.onLogout(), styleClass: 'p-menuitem-danger' }
+        ];
+    }
 
     toggleDarkMode() {
         this.layoutService.layoutConfig.update((state) => ({ ...state, darkTheme: !state.darkTheme }));
+    }
+
+    onChangePassword() {
+        this.router.navigate(['/change-password']);
+    }
+
+    onLogout() {
+        this.authService.logout().subscribe();
     }
 }

--- a/frontend/src/assets/layout/_topbar.scss
+++ b/frontend/src/assets/layout/_topbar.scss
@@ -97,6 +97,10 @@
     }
 }
 
+.user-menu {
+    margin-top: 0.5rem;
+}
+
 @media (max-width: 991px) {
     .layout-topbar {
         padding: 0 2rem;


### PR DESCRIPTION
## Summary
- add authenticated user dropdown in topbar with change password and logout
- create change-password component and route
- tweak topbar styles for user menu overlay

## Testing
- `npm run build:frontend`

------
https://chatgpt.com/codex/tasks/task_e_6894fe290948832eb737924177d76a62