### PR TITLE
feat: support user deactivation

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -117,18 +117,18 @@ router.put('/:id', async (req, res, next) => {
   }
 });
 
-// Delete user
+// Deactivate user
 router.delete('/:id', (req, res, next) => {
   const db = getDatabase();
-  db.run('DELETE FROM users WHERE id = ?', [req.params.id], function(err) {
+  db.run('UPDATE users SET is_active = 0 WHERE id = ?', [req.params.id], function(err) {
     if (err) {
-      console.error('❌ Erro ao deletar usuário:', err.message);
-      return next(new ApiError(500, 'Erro ao deletar usuário', 'DELETE_USER_ERROR', err.message));
+      console.error('❌ Erro ao desativar usuário:', err.message);
+      return next(new ApiError(500, 'Erro ao desativar usuário', 'DEACTIVATE_USER_ERROR', err.message));
     }
     if (this.changes === 0) {
       return next(new ApiError(404, 'Usuário não encontrado', 'USER_NOT_FOUND'));
     }
-    res.json({ message: 'Usuário deletado com sucesso' });
+    res.json({ message: 'Usuário desativado' });
   });
 });
 

--- a/frontend/src/app/components/users/user-list.html
+++ b/frontend/src/app/components/users/user-list.html
@@ -10,6 +10,7 @@
         <th>Usuário</th>
         <th>Email</th>
         <th>Nome</th>
+        <th>Status</th>
         <th>Ações</th>
       </tr>
     </ng-template>
@@ -19,8 +20,12 @@
         <td>{{ user.email }}</td>
         <td>{{ user.fullName }}</td>
         <td>
+          <p-tag [value]="user.is_active ? 'Ativo' : 'Inativo'" [severity]="user.is_active ? 'success' : 'danger'"></p-tag>
+        </td>
+        <td>
           <p-button icon="pi pi-pencil" [rounded]="true" [text]="true" (onClick)="editUser(user.id)"></p-button>
-          <p-button icon="pi pi-trash" [rounded]="true" [text]="true" severity="danger" (onClick)="deleteUser(user.id)"></p-button>
+          <p-button *ngIf="user.is_active" icon="pi pi-user-minus" [rounded]="true" [text]="true" severity="danger" (onClick)="toggleActive(user)"></p-button>
+          <p-button *ngIf="!user.is_active" icon="pi pi-user-plus" [rounded]="true" [text]="true" severity="success" (onClick)="toggleActive(user)"></p-button>
         </td>
       </tr>
     </ng-template>

--- a/frontend/src/app/components/users/user-list.ts
+++ b/frontend/src/app/components/users/user-list.ts
@@ -1,6 +1,6 @@
 /**
  * Lista de Usuários
- * Exibe todos os usuários com ações de edição e exclusão
+ * Exibe todos os usuários com ações de edição e ativação/desativação
  */
 
 import { Component, OnInit } from '@angular/core';
@@ -11,6 +11,7 @@ import { Router } from '@angular/router';
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { ToastModule } from 'primeng/toast';
+import { TagModule } from 'primeng/tag';
 import { MessageService } from 'primeng/api';
 
 import { UserService, AppUser } from '../../services/users';
@@ -18,7 +19,7 @@ import { UserService, AppUser } from '../../services/users';
 @Component({
   selector: 'app-user-list',
   standalone: true,
-  imports: [CommonModule, TableModule, ButtonModule, ToastModule],
+  imports: [CommonModule, TableModule, ButtonModule, ToastModule, TagModule],
   providers: [MessageService],
   templateUrl: './user-list.html',
   styleUrls: ['./user-list.scss']
@@ -55,16 +56,23 @@ export class UserListComponent implements OnInit {
     if (id) this.router.navigate(['/users', id]);
   }
 
-  deleteUser(id?: number): void {
-    if (!id) return;
-    if (!confirm('Deseja excluir este usuário?')) return;
-    this.userService.deleteUser(id).subscribe({
+  toggleActive(user: AppUser): void {
+    if (!user.id) return;
+    const action = user.is_active ? 'desativar' : 'reativar';
+    if (!confirm(`Deseja ${action} este usuário?`)) return;
+    const request = user.is_active
+      ? this.userService.deleteUser(user.id)
+      : this.userService.updateUser(user.id, { is_active: true });
+
+    request.subscribe({
       next: () => {
-        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Usuário removido' });
+        const detail = user.is_active ? 'Usuário desativado' : 'Usuário reativado';
+        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail });
         this.loadUsers();
       },
-      error: err => {
-        this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao remover usuário' });
+      error: () => {
+        const detail = user.is_active ? 'Falha ao desativar usuário' : 'Falha ao reativar usuário';
+        this.messageService.add({ severity: 'error', summary: 'Erro', detail });
       }
     });
   }


### PR DESCRIPTION
## Summary
- deactivate users instead of deleting them in backend API
- show user status in the frontend list and allow reactivation

## Testing
- `cd backend && npm test` (fails: Missing script "test")
- `cd frontend && npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689505c818ec832eb4093f07beb85bdc