### PR TITLE
Filter active users from API responses

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -8,15 +8,14 @@ const router = express.Router();
 // List all users
 router.get('/', (req, res, next) => {
   const db = getDatabase();
-  db.all('SELECT id, username, email, full_name, created_at, updated_at, is_active FROM users', [], (err, rows) => {
+  db.all('SELECT id, username, email, full_name, created_at, updated_at FROM users WHERE is_active = 1', [], (err, rows) => {
     if (err) {
       console.error('❌ Erro ao listar usuários:', err.message);
       return next(new ApiError(500, 'Erro ao listar usuários', 'LIST_USERS_ERROR', err.message));
     }
-    const formattedRows = rows.map(({ full_name, is_active, ...rest }) => ({
+    const formattedRows = rows.map(({ full_name, ...rest }) => ({
       ...rest,
-      fullName: full_name,
-      is_active: Boolean(is_active)
+      fullName: full_name
     }));
     res.json(formattedRows);
   });
@@ -25,7 +24,7 @@ router.get('/', (req, res, next) => {
 // Get single user
 router.get('/:id', (req, res, next) => {
   const db = getDatabase();
-  db.get('SELECT id, username, email, full_name, created_at, updated_at, is_active FROM users WHERE id = ?', [req.params.id], (err, row) => {
+  db.get('SELECT id, username, email, full_name, created_at, updated_at FROM users WHERE id = ? AND is_active = 1', [req.params.id], (err, row) => {
     if (err) {
       console.error('❌ Erro ao obter usuário:', err.message);
       return next(new ApiError(500, 'Erro ao obter usuário', 'GET_USER_ERROR', err.message));
@@ -33,8 +32,8 @@ router.get('/:id', (req, res, next) => {
     if (!row) {
       return next(new ApiError(404, 'Usuário não encontrado', 'USER_NOT_FOUND'));
     }
-    const { full_name, is_active, ...rest } = row;
-    res.json({ ...rest, fullName: full_name, is_active: Boolean(is_active) });
+    const { full_name, ...rest } = row;
+    res.json({ ...rest, fullName: full_name });
   });
 });
 

--- a/frontend/src/app/services/users.ts
+++ b/frontend/src/app/services/users.ts
@@ -14,7 +14,6 @@ export interface AppUser {
   email: string;
   fullName?: string;
   password?: string;
-  is_active?: boolean;
 }
 
 @Injectable({
@@ -28,7 +27,7 @@ export class UserService {
   getUsers(): Observable<AppUser[]> {
     return this.http.get<any[]>(`${this.API_URL}/users`).pipe(
       map((users: any[]) =>
-        users.map(({ full_name, ...user }: any) => ({
+        users.map(({ full_name, is_active: _is_active, ...user }: any) => ({
           ...user,
           fullName: full_name,
         }) as AppUser)
@@ -42,7 +41,7 @@ export class UserService {
 
   getUser(id: number): Observable<AppUser> {
     return this.http.get<any>(`${this.API_URL}/users/${id}`).pipe(
-      map(({ full_name, ...user }: any) => ({
+      map(({ full_name, is_active: _is_active, ...user }: any) => ({
         ...user,
         fullName: full_name,
       }) as AppUser),


### PR DESCRIPTION
## Summary
- return only active users in backend list and details endpoints
- adjust frontend user service to match updated user data

## Testing
- `npm test` *(backend)*
- `npm test` *(frontend)*

------
https://chatgpt.com/codex/tasks/task_e_689505c8831c832eb4142a90c79cf7dd