### PR TITLE
feat: enforce strong password on user creation

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -213,9 +213,16 @@ router.post('/register', async (req, res, next) => {
       return next(new ApiError(400, 'Formato de email inválido', 'INVALID_EMAIL'));
     }
 
-    // Validar senha (mínimo 6 caracteres)
-    if (password.length < 6) {
-      return next(new ApiError(400, 'Senha deve ter pelo menos 6 caracteres', 'PASSWORD_TOO_SHORT'));
+    // Validar senha forte: mínimo 8 caracteres, uma letra maiúscula e um caractere especial
+    const strongPassword = /^(?=.*[A-Z])(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/;
+    if (!strongPassword.test(password)) {
+      return next(
+        new ApiError(
+          400,
+          'Senha deve ter pelo menos 8 caracteres, incluir letra maiúscula e caractere especial',
+          'WEAK_PASSWORD'
+        )
+      );
     }
 
     const db = getDatabase();

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -45,6 +45,18 @@ router.post('/', async (req, res, next) => {
     if (!username || !email || !password) {
       return next(new ApiError(400, 'Username, email e senha são obrigatórios', 'MISSING_FIELDS'));
     }
+
+    // Validar senha forte: mínimo 8 caracteres, uma letra maiúscula e um caractere especial
+    const strongPassword = /^(?=.*[A-Z])(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/;
+    if (!strongPassword.test(password)) {
+      return next(
+        new ApiError(
+          400,
+          'Senha deve ter pelo menos 8 caracteres, incluir letra maiúscula e caractere especial',
+          'WEAK_PASSWORD'
+        )
+      );
+    }
     const db = getDatabase();
     db.get('SELECT id FROM users WHERE username = ? OR email = ?', [username, email], async (err, existing) => {
       if (err) {

--- a/frontend/src/app/components/users/user-form.ts
+++ b/frontend/src/app/components/users/user-form.ts
@@ -31,6 +31,7 @@ export class UserFormComponent implements OnInit {
   isEdit = false;
   isLoading = false;
   private userId?: number;
+  private readonly strongPassword = /^(?=.*[A-Z])(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/;
 
   constructor(private userService: UserService, private route: ActivatedRoute, private router: Router, private messageService: MessageService) {}
 
@@ -64,6 +65,19 @@ export class UserFormComponent implements OnInit {
 
   onSubmit(): void {
     this.isLoading = true;
+
+    // Verifica força da senha quando criando usuário ou alterando senha
+    const needsValidation = !this.isEdit || !!this.user.password;
+    if (needsValidation && !this.strongPassword.test(this.user.password || '')) {
+      this.isLoading = false;
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Senha fraca',
+        detail: 'Senha deve ter pelo menos 8 caracteres, incluir letra maiúscula e caractere especial'
+      });
+      return;
+    }
+
     const request = this.isEdit && this.userId
       ? this.userService.updateUser(this.userId, this.user)
       : this.userService.createUser(this.user);


### PR DESCRIPTION
## Summary
- validate strong passwords on backend user creation routes
- verify password strength before submitting user form

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689517326cbc832ea5b941d8b6078d92