### PR TITLE
feat: add reserva-evento component

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -31,6 +31,7 @@ export const routes: Routes = [
       { path: 'users/new', loadComponent: () => import('./components/users/user-form').then(m => m.UserFormComponent) },
       { path: 'users/:id', loadComponent: () => import('./components/users/user-form').then(m => m.UserFormComponent) },
       { path: 'change-password', loadComponent: () => import('./components/change-password/change-password').then(m => m.ChangePasswordComponent) },
+      { path: 'reserva-evento', loadComponent: () => import('./reserva-evento/reserva-evento').then(m => m.ReservaEventoComponent) },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: '**', redirectTo: 'dashboard' }
     ]

--- a/frontend/src/app/components/layout/component/app.menu.ts
+++ b/frontend/src/app/components/layout/component/app.menu.ts
@@ -28,6 +28,7 @@ export class AppMenu {
         label: 'Cadastros',
         items: [
             { label: 'Usuários', icon: 'pi pi-fw pi-id-card', routerLink: ['/users'] },
+            { label: 'Reserva Evento', icon: 'pi pi-fw pi-calendar-plus', routerLink: ['/reserva-evento'] },
         ]
       },
     ];

--- a/frontend/src/app/reserva-evento/reserva-evento.html
+++ b/frontend/src/app/reserva-evento/reserva-evento.html
@@ -1,0 +1,53 @@
+<p-toast></p-toast>
+
+<div class="filters">
+  <p-select [(ngModel)]="filtroRestaurante" [options]="eventos" optionLabel="restaurante" optionValue="restaurante" placeholder="Restaurante"></p-select>
+  <p-select [(ngModel)]="filtroEvento" [options]="eventos" optionLabel="nome" optionValue="id" placeholder="Evento"></p-select>
+  <p-datepicker [(ngModel)]="filtroData" dateFormat="yy-mm-dd" placeholder="Data"></p-datepicker>
+  <button pButton type="button" label="Filtrar" (click)="aplicarFiltros()"></button>
+</div>
+
+<div class="lists">
+  <h3>Reservas</h3>
+  <p-table [value]="reservas">
+    <ng-template pTemplate="header">
+      <tr>
+        <th>Cliente</th>
+        <th>Restaurante</th>
+        <th>Data</th>
+      </tr>
+    </ng-template>
+    <ng-template pTemplate="body" let-reserva>
+      <tr>
+        <td>{{ reserva.cliente }}</td>
+        <td>{{ reserva.restaurante }}</td>
+        <td>{{ reserva.data }}</td>
+      </tr>
+    </ng-template>
+  </p-table>
+
+  <h3>Eventos</h3>
+  <p-table [value]="eventos">
+    <ng-template pTemplate="header">
+      <tr>
+        <th>Nome</th>
+        <th>Restaurante</th>
+        <th>Data</th>
+      </tr>
+    </ng-template>
+    <ng-template pTemplate="body" let-evento>
+      <tr>
+        <td>{{ evento.nome }}</td>
+        <td>{{ evento.restaurante }}</td>
+        <td>{{ evento.data }}</td>
+      </tr>
+    </ng-template>
+  </p-table>
+</div>
+
+<div class="form">
+  <h3>Vincular Reserva a Evento</h3>
+  <p-select [(ngModel)]="reservaSelecionada" [options]="reservas" optionLabel="cliente" placeholder="Selecione a reserva"></p-select>
+  <p-select [(ngModel)]="eventoSelecionado" [options]="eventos" optionLabel="nome" placeholder="Selecione o evento"></p-select>
+  <button pButton type="button" label="Vincular" (click)="vincular()" [disabled]="!reservaSelecionada || !eventoSelecionado"></button>
+</div>

--- a/frontend/src/app/reserva-evento/reserva-evento.scss
+++ b/frontend/src/app/reserva-evento/reserva-evento.scss
@@ -1,0 +1,11 @@
+.filters, .form {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.lists {
+  margin-bottom: 2rem;
+}

--- a/frontend/src/app/reserva-evento/reserva-evento.ts
+++ b/frontend/src/app/reserva-evento/reserva-evento.ts
@@ -1,0 +1,93 @@
+/**
+ * Componente de vinculação de reservas a eventos
+ * Lista eventos e reservas, permite filtrar e realizar a vinculação
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+// PrimeNG
+import { TableModule } from 'primeng/table';
+import { SelectModule } from 'primeng/select';
+import { DatePickerModule } from 'primeng/datepicker';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+
+import { ReservaEventoService, Reserva, Evento } from '../services/reserva-evento';
+
+@Component({
+  selector: 'app-reserva-evento',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TableModule, SelectModule, DatePickerModule, ButtonModule, ToastModule],
+  providers: [MessageService],
+  templateUrl: './reserva-evento.html',
+  styleUrls: ['./reserva-evento.scss']
+})
+export class ReservaEventoComponent implements OnInit {
+  reservas: Reserva[] = [];
+  eventos: Evento[] = [];
+
+  // filtros
+  filtroRestaurante?: number;
+  filtroEvento?: number;
+  filtroData?: Date | null;
+
+  // seleção para vinculação
+  reservaSelecionada?: Reserva;
+  eventoSelecionado?: Evento;
+
+  constructor(private reservaEventoService: ReservaEventoService, private messageService: MessageService) {}
+
+  ngOnInit(): void {
+    this.carregarDados();
+  }
+
+  carregarDados(): void {
+    const filtros: any = {
+      restaurante: this.filtroRestaurante,
+      evento: this.filtroEvento,
+      data: this.filtroData ? this.filtroData.toISOString().split('T')[0] : undefined
+    };
+
+    this.reservaEventoService.getReservas(filtros).subscribe({
+      next: data => (this.reservas = data),
+      error: () => this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao carregar reservas' })
+    });
+
+    this.reservaEventoService.getEventos(filtros).subscribe({
+      next: data => (this.eventos = data),
+      error: () => this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao carregar eventos' })
+    });
+  }
+
+  aplicarFiltros(): void {
+    this.carregarDados();
+  }
+
+  vincular(): void {
+    if (!this.reservaSelecionada || !this.eventoSelecionado) return;
+    this.reservaEventoService
+      .vincular(this.reservaSelecionada.id!, this.eventoSelecionado.id!)
+      .subscribe({
+        next: () => {
+          this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Reserva vinculada ao evento' });
+          this.carregarDados();
+        },
+        error: err => {
+          let detail = 'Falha ao vincular reserva';
+          const msg = err.error?.message || '';
+          if (msg.toLowerCase().includes('capacidade')) {
+            detail = 'Capacidade do evento excedida';
+          } else if (msg.toLowerCase().includes('restaurante')) {
+            detail = 'Não é permitido múltiplos restaurantes no mesmo dia';
+          } else if (msg.toLowerCase().includes('duração')) {
+            detail = 'Limite de eventos por duração excedido';
+          }
+          this.messageService.add({ severity: 'error', summary: 'Erro', detail });
+        }
+      });
+  }
+}
+

--- a/frontend/src/app/services/reserva-evento.ts
+++ b/frontend/src/app/services/reserva-evento.ts
@@ -1,0 +1,59 @@
+/**
+ * Serviço para listar eventos e reservas e vincular ambos
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, catchError, throwError } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface Reserva {
+  id?: number;
+  cliente?: string;
+  restaurante?: string;
+  data?: string;
+}
+
+export interface Evento {
+  id?: number;
+  nome?: string;
+  restaurante?: string;
+  data?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ReservaEventoService {
+  private readonly API_URL = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getReservas(params?: any): Observable<Reserva[]> {
+    return this.http.get<Reserva[]>(`${this.API_URL}/reservas`, { params }).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao listar reservas:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  getEventos(params?: any): Observable<Evento[]> {
+    return this.http.get<Evento[]>(`${this.API_URL}/eventos`, { params }).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao listar eventos:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  vincular(reservaId: number, eventoId: number): Observable<any> {
+    return this.http.post(`${this.API_URL}/reservas/${reservaId}/evento`, { eventoId }).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao vincular reserva ao evento:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add component to list reservations and events with filter and link form
- handle backend capacity and scheduling conflicts
- expose service and route for linking reservations to events

## Testing
- `npm run build:frontend`

------
https://chatgpt.com/codex/tasks/task_e_68951b168f60832eb47f0f96dcf407d0