### PR TITLE
feat: add CRUD services and models

### DIFF
--- a/frontend/src/app/models/evento.ts
+++ b/frontend/src/app/models/evento.ts
@@ -1,0 +1,10 @@
+/**
+ * Modelo de Evento
+ */
+export interface Evento {
+  id?: number;
+  nome: string;
+  descricao?: string;
+  data: string; // ISO string
+  restauranteId?: number;
+}

--- a/frontend/src/app/models/reserva.ts
+++ b/frontend/src/app/models/reserva.ts
@@ -1,0 +1,11 @@
+/**
+ * Modelo de Reserva
+ */
+export interface Reserva {
+  id?: number;
+  cliente: string;
+  data: string; // ISO string
+  pessoas: number;
+  restauranteId?: number;
+  eventoId?: number;
+}

--- a/frontend/src/app/models/restaurante.ts
+++ b/frontend/src/app/models/restaurante.ts
@@ -1,0 +1,10 @@
+/**
+ * Modelo de Restaurante
+ */
+export interface Restaurante {
+  id?: number;
+  nome: string;
+  descricao?: string;
+  endereco?: string;
+  capacidade?: number;
+}

--- a/frontend/src/app/services/evento.service.ts
+++ b/frontend/src/app/services/evento.service.ts
@@ -1,0 +1,64 @@
+/**
+ * Serviço de Eventos
+ * CRUD de eventos do sistema
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable, catchError, throwError } from 'rxjs';
+import { Evento } from '../models/evento';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EventoService {
+  private readonly API_URL = `${environment.apiUrl}/eventos`;
+
+  constructor(private http: HttpClient) {}
+
+  getEventos(): Observable<Evento[]> {
+    return this.http.get<Evento[]>(this.API_URL).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao listar eventos:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  getEvento(id: number): Observable<Evento> {
+    return this.http.get<Evento>(`${this.API_URL}/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao obter evento:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  createEvento(data: Evento): Observable<Evento> {
+    return this.http.post<Evento>(this.API_URL, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao criar evento:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  updateEvento(id: number, data: Partial<Evento>): Observable<Evento> {
+    return this.http.put<Evento>(`${this.API_URL}/${id}`, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao atualizar evento:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  deleteEvento(id: number): Observable<any> {
+    return this.http.delete(`${this.API_URL}/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao deletar evento:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+}

--- a/frontend/src/app/services/reserva.service.ts
+++ b/frontend/src/app/services/reserva.service.ts
@@ -1,0 +1,64 @@
+/**
+ * Serviço de Reservas
+ * CRUD de reservas do sistema
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable, catchError, throwError } from 'rxjs';
+import { Reserva } from '../models/reserva';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ReservaService {
+  private readonly API_URL = `${environment.apiUrl}/reservas`;
+
+  constructor(private http: HttpClient) {}
+
+  getReservas(): Observable<Reserva[]> {
+    return this.http.get<Reserva[]>(this.API_URL).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao listar reservas:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  getReserva(id: number): Observable<Reserva> {
+    return this.http.get<Reserva>(`${this.API_URL}/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao obter reserva:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  createReserva(data: Reserva): Observable<Reserva> {
+    return this.http.post<Reserva>(this.API_URL, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao criar reserva:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  updateReserva(id: number, data: Partial<Reserva>): Observable<Reserva> {
+    return this.http.put<Reserva>(`${this.API_URL}/${id}`, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao atualizar reserva:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  deleteReserva(id: number): Observable<any> {
+    return this.http.delete(`${this.API_URL}/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao deletar reserva:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+}

--- a/frontend/src/app/services/restaurante.service.ts
+++ b/frontend/src/app/services/restaurante.service.ts
@@ -1,0 +1,64 @@
+/**
+ * Serviço de Restaurantes
+ * CRUD de restaurantes do sistema
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable, catchError, throwError } from 'rxjs';
+import { Restaurante } from '../models/restaurante';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RestauranteService {
+  private readonly API_URL = `${environment.apiUrl}/restaurantes`;
+
+  constructor(private http: HttpClient) {}
+
+  getRestaurantes(): Observable<Restaurante[]> {
+    return this.http.get<Restaurante[]>(this.API_URL).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao listar restaurantes:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  getRestaurante(id: number): Observable<Restaurante> {
+    return this.http.get<Restaurante>(`${this.API_URL}/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao obter restaurante:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  createRestaurante(data: Restaurante): Observable<Restaurante> {
+    return this.http.post<Restaurante>(this.API_URL, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao criar restaurante:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  updateRestaurante(id: number, data: Partial<Restaurante>): Observable<Restaurante> {
+    return this.http.put<Restaurante>(`${this.API_URL}/${id}`, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao atualizar restaurante:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  deleteRestaurante(id: number): Observable<any> {
+    return this.http.delete(`${this.API_URL}/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao deletar restaurante:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add Restaurante, Evento and Reserva interfaces
- implement corresponding HttpClient services using centralized API URL

## Testing
- `npm run build:frontend`

------
https://chatgpt.com/codex/tasks/task_e_68951b15db84832e8c5bfa4a12f342c7