### PR TITLE
feat: add restaurant, event and reservation forms

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -31,6 +31,15 @@ export const routes: Routes = [
       { path: 'users/new', loadComponent: () => import('./components/users/user-form').then(m => m.UserFormComponent) },
       { path: 'users/:id', loadComponent: () => import('./components/users/user-form').then(m => m.UserFormComponent) },
       { path: 'change-password', loadComponent: () => import('./components/change-password/change-password').then(m => m.ChangePasswordComponent) },
+      { path: 'restaurantes', loadComponent: () => import('./components/restaurantes/restaurante-list').then(m => m.RestauranteListComponent) },
+      { path: 'restaurantes/novo', loadComponent: () => import('./components/restaurantes/restaurante-form').then(m => m.RestauranteFormComponent) },
+      { path: 'restaurantes/:id', loadComponent: () => import('./components/restaurantes/restaurante-form').then(m => m.RestauranteFormComponent) },
+      { path: 'eventos', loadComponent: () => import('./components/eventos/evento-list').then(m => m.EventoListComponent) },
+      { path: 'eventos/novo', loadComponent: () => import('./components/eventos/evento-form').then(m => m.EventoFormComponent) },
+      { path: 'eventos/:id', loadComponent: () => import('./components/eventos/evento-form').then(m => m.EventoFormComponent) },
+      { path: 'reservas', loadComponent: () => import('./components/reservas/reserva-list').then(m => m.ReservaListComponent) },
+      { path: 'reservas/novo', loadComponent: () => import('./components/reservas/reserva-form').then(m => m.ReservaFormComponent) },
+      { path: 'reservas/:id', loadComponent: () => import('./components/reservas/reserva-form').then(m => m.ReservaFormComponent) },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: '**', redirectTo: 'dashboard' }
     ]

--- a/frontend/src/app/components/eventos/evento-form.html
+++ b/frontend/src/app/components/eventos/evento-form.html
@@ -1,0 +1,30 @@
+<p-card header="{{ isEdit ? 'Editar Evento' : 'Novo Evento' }}">
+  <form [formGroup]="form" (ngSubmit)="onSubmit()">
+    <div class="field">
+      <label for="nome">Nome</label>
+      <input id="nome" type="text" pInputText formControlName="nome" />
+      <div class="error" *ngIf="form.get('nome')?.hasError('required') && form.get('nome')?.touched">Nome é obrigatório.</div>
+    </div>
+
+    <div class="field">
+      <label for="data">Data (YYYY-MM-DD)</label>
+      <input id="data" type="text" pInputText formControlName="data" />
+      <div class="error" *ngIf="form.get('data')?.hasError('required') && form.get('data')?.touched">Data é obrigatória.</div>
+      <div class="error" *ngIf="form.get('data')?.hasError('pattern') && form.get('data')?.touched">Formato de data inválido.</div>
+    </div>
+
+    <div class="field">
+      <label for="hora">Hora (HH:mm)</label>
+      <input id="hora" type="text" pInputText formControlName="hora" />
+      <div class="error" *ngIf="form.get('hora')?.hasError('required') && form.get('hora')?.touched">Hora é obrigatória.</div>
+      <div class="error" *ngIf="form.get('hora')?.hasError('pattern') && form.get('hora')?.touched">Formato de hora inválido.</div>
+    </div>
+
+    <div class="actions">
+      <button pButton type="submit" label="Salvar" [disabled]="isLoading"></button>
+      <button pButton type="button" label="Cancelar" class="p-button-secondary" (click)="cancel()"></button>
+    </div>
+  </form>
+</p-card>
+
+<p-toast></p-toast>

--- a/frontend/src/app/components/eventos/evento-form.scss
+++ b/frontend/src/app/components/eventos/evento-form.scss
@@ -1,0 +1,13 @@
+.field {
+  margin-bottom: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.error {
+  color: red;
+  font-size: 0.8rem;
+}

--- a/frontend/src/app/components/eventos/evento-form.ts
+++ b/frontend/src/app/components/eventos/evento-form.ts
@@ -1,0 +1,96 @@
+/**
+ * Formulário de Evento
+ * Usado para criação e edição de eventos
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+
+// PrimeNG
+import { CardModule } from 'primeng/card';
+import { InputTextModule } from 'primeng/inputtext';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+
+import { EventoService, Evento } from '../../services/eventos';
+
+@Component({
+  selector: 'app-evento-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, CardModule, InputTextModule, ButtonModule, ToastModule],
+  providers: [MessageService],
+  templateUrl: './evento-form.html',
+  styleUrls: ['./evento-form.scss']
+})
+export class EventoFormComponent implements OnInit {
+  form: FormGroup;
+  isEdit = false;
+  isLoading = false;
+  private id?: number;
+
+  constructor(
+    private fb: FormBuilder,
+    private service: EventoService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private messageService: MessageService
+  ) {
+    this.form = this.fb.group({
+      nome: ['', Validators.required],
+      data: ['', [Validators.required, Validators.pattern(/^\d{4}-\d{2}-\d{2}$/)]],
+      hora: ['', [Validators.required, Validators.pattern(/^\d{2}:\d{2}$/)]]
+    });
+  }
+
+  ngOnInit(): void {
+    const idParam = this.route.snapshot.paramMap.get('id');
+    if (idParam) {
+      this.id = Number(idParam);
+      this.isEdit = true;
+      this.service.getEvento(this.id).subscribe({
+        next: data => this.form.patchValue(data),
+        error: err => this.showError('Erro ao carregar evento', err)
+      });
+    }
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isLoading = true;
+    const value = this.form.value as Evento;
+    const request = this.isEdit && this.id
+      ? this.service.updateEvento(this.id, value)
+      : this.service.createEvento(value);
+
+    request.subscribe({
+      next: () => {
+        this.isLoading = false;
+        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Evento salvo' });
+        this.router.navigate(['/eventos']);
+      },
+      error: err => {
+        this.isLoading = false;
+        this.showError('Erro ao salvar evento', err);
+      }
+    });
+  }
+
+  cancel(): void {
+    this.router.navigate(['/eventos']);
+  }
+
+  private showError(summary: string, err: any): void {
+    let detail = 'Falha na operação';
+    if (err.status >= 400 && err.status < 500) {
+      detail = err.error?.message || 'Dados inválidos';
+    }
+    this.messageService.add({ severity: 'error', summary, detail });
+  }
+}

--- a/frontend/src/app/components/eventos/evento-list.html
+++ b/frontend/src/app/components/eventos/evento-list.html
@@ -1,0 +1,12 @@
+<p-card header="Eventos">
+  <button pButton label="Novo" (click)="novo()" class="mb-3"></button>
+  <ul>
+    <li *ngFor="let e of eventos">
+      {{ e.nome }} - {{ e.data }} {{ e.hora }}
+      <button pButton label="Editar" class="p-button-text" (click)="editar(e.id)"></button>
+      <button pButton label="Excluir" class="p-button-text p-button-danger" (click)="excluir(e.id)"></button>
+    </li>
+  </ul>
+</p-card>
+
+<p-toast></p-toast>

--- a/frontend/src/app/components/eventos/evento-list.scss
+++ b/frontend/src/app/components/eventos/evento-list.scss
@@ -1,0 +1,11 @@
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/app/components/eventos/evento-list.ts
+++ b/frontend/src/app/components/eventos/evento-list.ts
@@ -1,0 +1,74 @@
+/**
+ * Lista de Eventos
+ * Exibe eventos com ações básicas
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Router } from '@angular/router';
+
+// PrimeNG
+import { CardModule } from 'primeng/card';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+
+import { EventoService, Evento } from '../../services/eventos';
+
+@Component({
+  selector: 'app-evento-list',
+  standalone: true,
+  imports: [CommonModule, RouterModule, CardModule, ButtonModule, ToastModule],
+  providers: [MessageService],
+  templateUrl: './evento-list.html',
+  styleUrls: ['./evento-list.scss']
+})
+export class EventoListComponent implements OnInit {
+  eventos: Evento[] = [];
+
+  constructor(
+    private service: EventoService,
+    private router: Router,
+    private messageService: MessageService
+  ) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.service.getEventos().subscribe({
+      next: data => this.eventos = data,
+      error: err => this.showError('Erro ao carregar eventos', err)
+    });
+  }
+
+  novo(): void {
+    this.router.navigate(['/eventos/novo']);
+  }
+
+  editar(id?: number): void {
+    if (id) {
+      this.router.navigate(['/eventos', id]);
+    }
+  }
+
+  excluir(id?: number): void {
+    if (!id) return;
+    this.service.deleteEvento(id).subscribe({
+      next: () => {
+        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Evento removido' });
+        this.load();
+      },
+      error: err => this.showError('Erro ao remover evento', err)
+    });
+  }
+
+  private showError(summary: string, err: any): void {
+    let detail = 'Falha na operação';
+    if (err.status >= 400 && err.status < 500) {
+      detail = err.error?.message || 'Requisição inválida';
+    }
+    this.messageService.add({ severity: 'error', summary, detail });
+  }
+}

--- a/frontend/src/app/components/reservas/reserva-form.html
+++ b/frontend/src/app/components/reservas/reserva-form.html
@@ -1,0 +1,30 @@
+<p-card header="{{ isEdit ? 'Editar Reserva' : 'Nova Reserva' }}">
+  <form [formGroup]="form" (ngSubmit)="onSubmit()">
+    <div class="field">
+      <label for="nome">Nome</label>
+      <input id="nome" type="text" pInputText formControlName="nome" />
+      <div class="error" *ngIf="form.get('nome')?.hasError('required') && form.get('nome')?.touched">Nome é obrigatório.</div>
+    </div>
+
+    <div class="field">
+      <label for="data">Data (YYYY-MM-DD)</label>
+      <input id="data" type="text" pInputText formControlName="data" />
+      <div class="error" *ngIf="form.get('data')?.hasError('required') && form.get('data')?.touched">Data é obrigatória.</div>
+      <div class="error" *ngIf="form.get('data')?.hasError('pattern') && form.get('data')?.touched">Formato de data inválido.</div>
+    </div>
+
+    <div class="field">
+      <label for="hora">Hora (HH:mm)</label>
+      <input id="hora" type="text" pInputText formControlName="hora" />
+      <div class="error" *ngIf="form.get('hora')?.hasError('required') && form.get('hora')?.touched">Hora é obrigatória.</div>
+      <div class="error" *ngIf="form.get('hora')?.hasError('pattern') && form.get('hora')?.touched">Formato de hora inválido.</div>
+    </div>
+
+    <div class="actions">
+      <button pButton type="submit" label="Salvar" [disabled]="isLoading"></button>
+      <button pButton type="button" label="Cancelar" class="p-button-secondary" (click)="cancel()"></button>
+    </div>
+  </form>
+</p-card>
+
+<p-toast></p-toast>

--- a/frontend/src/app/components/reservas/reserva-form.scss
+++ b/frontend/src/app/components/reservas/reserva-form.scss
@@ -1,0 +1,13 @@
+.field {
+  margin-bottom: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.error {
+  color: red;
+  font-size: 0.8rem;
+}

--- a/frontend/src/app/components/reservas/reserva-form.ts
+++ b/frontend/src/app/components/reservas/reserva-form.ts
@@ -1,0 +1,96 @@
+/**
+ * Formulário de Reserva
+ * Usado para criação e edição de reservas
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+
+// PrimeNG
+import { CardModule } from 'primeng/card';
+import { InputTextModule } from 'primeng/inputtext';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+
+import { ReservaService, Reserva } from '../../services/reservas';
+
+@Component({
+  selector: 'app-reserva-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, CardModule, InputTextModule, ButtonModule, ToastModule],
+  providers: [MessageService],
+  templateUrl: './reserva-form.html',
+  styleUrls: ['./reserva-form.scss']
+})
+export class ReservaFormComponent implements OnInit {
+  form: FormGroup;
+  isEdit = false;
+  isLoading = false;
+  private id?: number;
+
+  constructor(
+    private fb: FormBuilder,
+    private service: ReservaService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private messageService: MessageService
+  ) {
+    this.form = this.fb.group({
+      nome: ['', Validators.required],
+      data: ['', [Validators.required, Validators.pattern(/^\d{4}-\d{2}-\d{2}$/)]],
+      hora: ['', [Validators.required, Validators.pattern(/^\d{2}:\d{2}$/)]]
+    });
+  }
+
+  ngOnInit(): void {
+    const idParam = this.route.snapshot.paramMap.get('id');
+    if (idParam) {
+      this.id = Number(idParam);
+      this.isEdit = true;
+      this.service.getReserva(this.id).subscribe({
+        next: data => this.form.patchValue(data),
+        error: err => this.showError('Erro ao carregar reserva', err)
+      });
+    }
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isLoading = true;
+    const value = this.form.value as Reserva;
+    const request = this.isEdit && this.id
+      ? this.service.updateReserva(this.id, value)
+      : this.service.createReserva(value);
+
+    request.subscribe({
+      next: () => {
+        this.isLoading = false;
+        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Reserva salva' });
+        this.router.navigate(['/reservas']);
+      },
+      error: err => {
+        this.isLoading = false;
+        this.showError('Erro ao salvar reserva', err);
+      }
+    });
+  }
+
+  cancel(): void {
+    this.router.navigate(['/reservas']);
+  }
+
+  private showError(summary: string, err: any): void {
+    let detail = 'Falha na operação';
+    if (err.status >= 400 && err.status < 500) {
+      detail = err.error?.message || 'Dados inválidos';
+    }
+    this.messageService.add({ severity: 'error', summary, detail });
+  }
+}

--- a/frontend/src/app/components/reservas/reserva-list.html
+++ b/frontend/src/app/components/reservas/reserva-list.html
@@ -1,0 +1,12 @@
+<p-card header="Reservas">
+  <button pButton label="Nova" (click)="novo()" class="mb-3"></button>
+  <ul>
+    <li *ngFor="let r of reservas">
+      {{ r.nome }} - {{ r.data }} {{ r.hora }}
+      <button pButton label="Editar" class="p-button-text" (click)="editar(r.id)"></button>
+      <button pButton label="Excluir" class="p-button-text p-button-danger" (click)="excluir(r.id)"></button>
+    </li>
+  </ul>
+</p-card>
+
+<p-toast></p-toast>

--- a/frontend/src/app/components/reservas/reserva-list.scss
+++ b/frontend/src/app/components/reservas/reserva-list.scss
@@ -1,0 +1,11 @@
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/app/components/reservas/reserva-list.ts
+++ b/frontend/src/app/components/reservas/reserva-list.ts
@@ -1,0 +1,74 @@
+/**
+ * Lista de Reservas
+ * Exibe reservas com ações básicas
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Router } from '@angular/router';
+
+// PrimeNG
+import { CardModule } from 'primeng/card';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+
+import { ReservaService, Reserva } from '../../services/reservas';
+
+@Component({
+  selector: 'app-reserva-list',
+  standalone: true,
+  imports: [CommonModule, RouterModule, CardModule, ButtonModule, ToastModule],
+  providers: [MessageService],
+  templateUrl: './reserva-list.html',
+  styleUrls: ['./reserva-list.scss']
+})
+export class ReservaListComponent implements OnInit {
+  reservas: Reserva[] = [];
+
+  constructor(
+    private service: ReservaService,
+    private router: Router,
+    private messageService: MessageService
+  ) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.service.getReservas().subscribe({
+      next: data => this.reservas = data,
+      error: err => this.showError('Erro ao carregar reservas', err)
+    });
+  }
+
+  novo(): void {
+    this.router.navigate(['/reservas/novo']);
+  }
+
+  editar(id?: number): void {
+    if (id) {
+      this.router.navigate(['/reservas', id]);
+    }
+  }
+
+  excluir(id?: number): void {
+    if (!id) return;
+    this.service.deleteReserva(id).subscribe({
+      next: () => {
+        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Reserva removida' });
+        this.load();
+      },
+      error: err => this.showError('Erro ao remover reserva', err)
+    });
+  }
+
+  private showError(summary: string, err: any): void {
+    let detail = 'Falha na operação';
+    if (err.status >= 400 && err.status < 500) {
+      detail = err.error?.message || 'Requisição inválida';
+    }
+    this.messageService.add({ severity: 'error', summary, detail });
+  }
+}

--- a/frontend/src/app/components/restaurantes/restaurante-form.html
+++ b/frontend/src/app/components/restaurantes/restaurante-form.html
@@ -1,0 +1,22 @@
+<p-card header="{{ isEdit ? 'Editar Restaurante' : 'Novo Restaurante' }}">
+  <form [formGroup]="form" (ngSubmit)="onSubmit()">
+    <div class="field">
+      <label for="nome">Nome</label>
+      <input id="nome" type="text" pInputText formControlName="nome" />
+      <div class="error" *ngIf="form.get('nome')?.hasError('required') && form.get('nome')?.touched">Nome é obrigatório.</div>
+    </div>
+
+    <div class="field">
+      <label for="localizacao">Localização</label>
+      <input id="localizacao" type="text" pInputText formControlName="localizacao" />
+      <div class="error" *ngIf="form.get('localizacao')?.hasError('required') && form.get('localizacao')?.touched">Localização é obrigatória.</div>
+    </div>
+
+    <div class="actions">
+      <button pButton type="submit" label="Salvar" [disabled]="isLoading"></button>
+      <button pButton type="button" label="Cancelar" class="p-button-secondary" (click)="cancel()"></button>
+    </div>
+  </form>
+</p-card>
+
+<p-toast></p-toast>

--- a/frontend/src/app/components/restaurantes/restaurante-form.scss
+++ b/frontend/src/app/components/restaurantes/restaurante-form.scss
@@ -1,0 +1,13 @@
+.field {
+  margin-bottom: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.error {
+  color: red;
+  font-size: 0.8rem;
+}

--- a/frontend/src/app/components/restaurantes/restaurante-form.ts
+++ b/frontend/src/app/components/restaurantes/restaurante-form.ts
@@ -1,0 +1,95 @@
+/**
+ * Formulário de Restaurante
+ * Usado para criação e edição de restaurantes
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+
+// PrimeNG
+import { CardModule } from 'primeng/card';
+import { InputTextModule } from 'primeng/inputtext';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+
+import { RestauranteService, Restaurante } from '../../services/restaurantes';
+
+@Component({
+  selector: 'app-restaurante-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, CardModule, InputTextModule, ButtonModule, ToastModule],
+  providers: [MessageService],
+  templateUrl: './restaurante-form.html',
+  styleUrls: ['./restaurante-form.scss']
+})
+export class RestauranteFormComponent implements OnInit {
+  form: FormGroup;
+  isEdit = false;
+  isLoading = false;
+  private id?: number;
+
+  constructor(
+    private fb: FormBuilder,
+    private service: RestauranteService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private messageService: MessageService
+  ) {
+    this.form = this.fb.group({
+      nome: ['', Validators.required],
+      localizacao: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    const idParam = this.route.snapshot.paramMap.get('id');
+    if (idParam) {
+      this.id = Number(idParam);
+      this.isEdit = true;
+      this.service.getRestaurante(this.id).subscribe({
+        next: data => this.form.patchValue(data),
+        error: err => this.showError('Erro ao carregar restaurante', err)
+      });
+    }
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isLoading = true;
+    const value = this.form.value as Restaurante;
+    const request = this.isEdit && this.id
+      ? this.service.updateRestaurante(this.id, value)
+      : this.service.createRestaurante(value);
+
+    request.subscribe({
+      next: () => {
+        this.isLoading = false;
+        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Restaurante salvo' });
+        this.router.navigate(['/restaurantes']);
+      },
+      error: err => {
+        this.isLoading = false;
+        this.showError('Erro ao salvar restaurante', err);
+      }
+    });
+  }
+
+  cancel(): void {
+    this.router.navigate(['/restaurantes']);
+  }
+
+  private showError(summary: string, err: any): void {
+    let detail = 'Falha na operação';
+    if (err.status >= 400 && err.status < 500) {
+      detail = err.error?.message || 'Dados inválidos';
+    }
+    this.messageService.add({ severity: 'error', summary, detail });
+  }
+}

--- a/frontend/src/app/components/restaurantes/restaurante-list.html
+++ b/frontend/src/app/components/restaurantes/restaurante-list.html
@@ -1,0 +1,12 @@
+<p-card header="Restaurantes">
+  <button pButton label="Novo" (click)="novo()" class="mb-3"></button>
+  <ul>
+    <li *ngFor="let r of restaurantes">
+      {{ r.nome }} - {{ r.localizacao }}
+      <button pButton label="Editar" class="p-button-text" (click)="editar(r.id)"></button>
+      <button pButton label="Excluir" class="p-button-text p-button-danger" (click)="excluir(r.id)"></button>
+    </li>
+  </ul>
+</p-card>
+
+<p-toast></p-toast>

--- a/frontend/src/app/components/restaurantes/restaurante-list.scss
+++ b/frontend/src/app/components/restaurantes/restaurante-list.scss
@@ -1,0 +1,11 @@
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/app/components/restaurantes/restaurante-list.ts
+++ b/frontend/src/app/components/restaurantes/restaurante-list.ts
@@ -1,0 +1,74 @@
+/**
+ * Lista de Restaurantes
+ * Exibe restaurantes com ações básicas
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Router } from '@angular/router';
+
+// PrimeNG
+import { CardModule } from 'primeng/card';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+
+import { RestauranteService, Restaurante } from '../../services/restaurantes';
+
+@Component({
+  selector: 'app-restaurante-list',
+  standalone: true,
+  imports: [CommonModule, RouterModule, CardModule, ButtonModule, ToastModule],
+  providers: [MessageService],
+  templateUrl: './restaurante-list.html',
+  styleUrls: ['./restaurante-list.scss']
+})
+export class RestauranteListComponent implements OnInit {
+  restaurantes: Restaurante[] = [];
+
+  constructor(
+    private service: RestauranteService,
+    private router: Router,
+    private messageService: MessageService
+  ) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.service.getRestaurantes().subscribe({
+      next: data => this.restaurantes = data,
+      error: err => this.showError('Erro ao carregar restaurantes', err)
+    });
+  }
+
+  novo(): void {
+    this.router.navigate(['/restaurantes/novo']);
+  }
+
+  editar(id?: number): void {
+    if (id) {
+      this.router.navigate(['/restaurantes', id]);
+    }
+  }
+
+  excluir(id?: number): void {
+    if (!id) return;
+    this.service.deleteRestaurante(id).subscribe({
+      next: () => {
+        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Restaurante removido' });
+        this.load();
+      },
+      error: err => this.showError('Erro ao remover restaurante', err)
+    });
+  }
+
+  private showError(summary: string, err: any): void {
+    let detail = 'Falha na operação';
+    if (err.status >= 400 && err.status < 500) {
+      detail = err.error?.message || 'Requisição inválida';
+    }
+    this.messageService.add({ severity: 'error', summary, detail });
+  }
+}

--- a/frontend/src/app/services/eventos.ts
+++ b/frontend/src/app/services/eventos.ts
@@ -1,0 +1,70 @@
+/**
+ * Serviço de Eventos
+ * CRUD de eventos do sistema
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable, catchError, throwError } from 'rxjs';
+
+export interface Evento {
+  id?: number;
+  nome: string;
+  data: string;
+  hora: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EventoService {
+  private readonly API_URL = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getEventos(): Observable<Evento[]> {
+    return this.http.get<Evento[]>(`${this.API_URL}/eventos`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao listar eventos:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  getEvento(id: number): Observable<Evento> {
+    return this.http.get<Evento>(`${this.API_URL}/eventos/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao obter evento:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  createEvento(data: Evento): Observable<any> {
+    return this.http.post(`${this.API_URL}/eventos`, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao criar evento:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  updateEvento(id: number, data: Partial<Evento>): Observable<any> {
+    return this.http.put(`${this.API_URL}/eventos/${id}`, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao atualizar evento:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  deleteEvento(id: number): Observable<any> {
+    return this.http.delete(`${this.API_URL}/eventos/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao deletar evento:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+}

--- a/frontend/src/app/services/reservas.ts
+++ b/frontend/src/app/services/reservas.ts
@@ -1,0 +1,70 @@
+/**
+ * Serviço de Reservas
+ * CRUD de reservas do sistema
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable, catchError, throwError } from 'rxjs';
+
+export interface Reserva {
+  id?: number;
+  nome: string;
+  data: string;
+  hora: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ReservaService {
+  private readonly API_URL = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getReservas(): Observable<Reserva[]> {
+    return this.http.get<Reserva[]>(`${this.API_URL}/reservas`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao listar reservas:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  getReserva(id: number): Observable<Reserva> {
+    return this.http.get<Reserva>(`${this.API_URL}/reservas/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao obter reserva:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  createReserva(data: Reserva): Observable<any> {
+    return this.http.post(`${this.API_URL}/reservas`, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao criar reserva:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  updateReserva(id: number, data: Partial<Reserva>): Observable<any> {
+    return this.http.put(`${this.API_URL}/reservas/${id}`, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao atualizar reserva:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  deleteReserva(id: number): Observable<any> {
+    return this.http.delete(`${this.API_URL}/reservas/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao deletar reserva:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+}

--- a/frontend/src/app/services/restaurantes.ts
+++ b/frontend/src/app/services/restaurantes.ts
@@ -1,0 +1,69 @@
+/**
+ * Serviço de Restaurantes
+ * CRUD de restaurantes do sistema
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable, catchError, throwError } from 'rxjs';
+
+export interface Restaurante {
+  id?: number;
+  nome: string;
+  localizacao: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RestauranteService {
+  private readonly API_URL = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getRestaurantes(): Observable<Restaurante[]> {
+    return this.http.get<Restaurante[]>(`${this.API_URL}/restaurantes`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao listar restaurantes:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  getRestaurante(id: number): Observable<Restaurante> {
+    return this.http.get<Restaurante>(`${this.API_URL}/restaurantes/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao obter restaurante:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  createRestaurante(data: Restaurante): Observable<any> {
+    return this.http.post(`${this.API_URL}/restaurantes`, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao criar restaurante:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  updateRestaurante(id: number, data: Partial<Restaurante>): Observable<any> {
+    return this.http.put(`${this.API_URL}/restaurantes/${id}`, data).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao atualizar restaurante:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  deleteRestaurante(id: number): Observable<any> {
+    return this.http.delete(`${this.API_URL}/restaurantes/${id}`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao deletar restaurante:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reactive forms and lists for restaurantes, eventos and reservas
- create supporting services and routes with friendly validation and error handling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68951b156398832ea9b9bcc1539ec0d7