### PR TITLE
feat: add routers for restaurants events reservations

### DIFF
--- a/backend/routes/eventos.js
+++ b/backend/routes/eventos.js
@@ -1,0 +1,126 @@
+const express = require('express');
+const { getDatabase } = require('../config/database');
+const { ApiError } = require('../middleware/errorHandler');
+
+const router = express.Router();
+
+function isValidDate(value) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function isValidTime(value) {
+  return /^\d{2}:\d{2}$/.test(value);
+}
+
+function isValidInt(value) {
+  return Number.isInteger(Number(value));
+}
+
+// List all events
+router.get('/', (req, res, next) => {
+  const db = getDatabase();
+  db.all('SELECT id, nome, data, horario, restaurante_id FROM eventos', [], (err, rows) => {
+    if (err) {
+      console.error('❌ Erro ao listar eventos:', err.message);
+      return next(new ApiError(500, 'Erro ao listar eventos', 'LIST_EVENTS_ERROR', err.message));
+    }
+    res.json(rows);
+  });
+});
+
+// Get single event
+router.get('/:id', (req, res, next) => {
+  if (!isValidInt(req.params.id)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  const db = getDatabase();
+  db.get('SELECT id, nome, data, horario, restaurante_id FROM eventos WHERE id = ?', [req.params.id], (err, row) => {
+    if (err) {
+      console.error('❌ Erro ao obter evento:', err.message);
+      return next(new ApiError(500, 'Erro ao obter evento', 'GET_EVENT_ERROR', err.message));
+    }
+    if (!row) {
+      return next(new ApiError(404, 'Evento não encontrado', 'EVENT_NOT_FOUND'));
+    }
+    res.json(row);
+  });
+});
+
+// Create event
+router.post('/', (req, res, next) => {
+  const { nome, data, horario, restauranteId } = req.body;
+  if (!nome || !isValidDate(data) || !isValidTime(horario) || !isValidInt(restauranteId)) {
+    return next(new ApiError(400, 'Dados inválidos para criação de evento', 'INVALID_FIELDS'));
+  }
+  const db = getDatabase();
+  db.run(
+    'INSERT INTO eventos (nome, data, horario, restaurante_id) VALUES (?, ?, ?, ?) RETURNING id',
+    [nome, data, horario, restauranteId],
+    function(err) {
+      if (err) {
+        console.error('❌ Erro ao criar evento:', err.message);
+        return next(new ApiError(500, 'Erro ao criar evento', 'CREATE_EVENT_ERROR', err.message));
+      }
+      res.status(201).json({ id: this.lastID, nome, data, horario, restauranteId });
+    }
+  );
+});
+
+// Update event
+router.put('/:id', (req, res, next) => {
+  if (!isValidInt(req.params.id)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  const { nome, data, horario, restauranteId } = req.body;
+  const fields = [];
+  const values = [];
+  if (nome) { fields.push('nome = ?'); values.push(nome); }
+  if (data) {
+    if (!isValidDate(data)) return next(new ApiError(400, 'Data inválida', 'INVALID_DATE'));
+    fields.push('data = ?'); values.push(data);
+  }
+  if (horario) {
+    if (!isValidTime(horario)) return next(new ApiError(400, 'Horário inválido', 'INVALID_TIME'));
+    fields.push('horario = ?'); values.push(horario);
+  }
+  if (restauranteId !== undefined) {
+    if (!isValidInt(restauranteId)) return next(new ApiError(400, 'RestauranteId deve ser inteiro', 'INVALID_RESTAURANT_ID'));
+    fields.push('restaurante_id = ?'); values.push(restauranteId);
+  }
+  if (fields.length === 0) {
+    return next(new ApiError(400, 'Nenhum dado para atualizar', 'NO_FIELDS_TO_UPDATE'));
+  }
+  values.push(req.params.id);
+  const sql = `UPDATE eventos SET ${fields.join(', ')} WHERE id = ?`;
+  const db = getDatabase();
+  db.run(sql, values, function(err) {
+    if (err) {
+      console.error('❌ Erro ao atualizar evento:', err.message);
+      return next(new ApiError(500, 'Erro ao atualizar evento', 'UPDATE_EVENT_ERROR', err.message));
+    }
+    if (this.changes === 0) {
+      return next(new ApiError(404, 'Evento não encontrado', 'EVENT_NOT_FOUND'));
+    }
+    res.json({ message: 'Evento atualizado com sucesso' });
+  });
+});
+
+// Delete event
+router.delete('/:id', (req, res, next) => {
+  if (!isValidInt(req.params.id)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  const db = getDatabase();
+  db.run('DELETE FROM eventos WHERE id = ?', [req.params.id], function(err) {
+    if (err) {
+      console.error('❌ Erro ao deletar evento:', err.message);
+      return next(new ApiError(500, 'Erro ao deletar evento', 'DELETE_EVENT_ERROR', err.message));
+    }
+    if (this.changes === 0) {
+      return next(new ApiError(404, 'Evento não encontrado', 'EVENT_NOT_FOUND'));
+    }
+    res.json({ message: 'Evento deletado com sucesso' });
+  });
+});
+
+module.exports = router;

--- a/backend/routes/reservas.js
+++ b/backend/routes/reservas.js
@@ -1,0 +1,133 @@
+const express = require('express');
+const { getDatabase } = require('../config/database');
+const { ApiError } = require('../middleware/errorHandler');
+
+const router = express.Router();
+
+function isValidDate(value) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function isValidTime(value) {
+  return /^\d{2}:\d{2}$/.test(value);
+}
+
+function isValidInt(value) {
+  return Number.isInteger(Number(value));
+}
+
+// List all reservations
+router.get('/', (req, res, next) => {
+  const db = getDatabase();
+  db.all('SELECT id, restaurante_id, evento_id, data, horario, numero_pessoas FROM reservas', [], (err, rows) => {
+    if (err) {
+      console.error('❌ Erro ao listar reservas:', err.message);
+      return next(new ApiError(500, 'Erro ao listar reservas', 'LIST_RESERVATIONS_ERROR', err.message));
+    }
+    res.json(rows);
+  });
+});
+
+// Get single reservation
+router.get('/:id', (req, res, next) => {
+  if (!isValidInt(req.params.id)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  const db = getDatabase();
+  db.get('SELECT id, restaurante_id, evento_id, data, horario, numero_pessoas FROM reservas WHERE id = ?', [req.params.id], (err, row) => {
+    if (err) {
+      console.error('❌ Erro ao obter reserva:', err.message);
+      return next(new ApiError(500, 'Erro ao obter reserva', 'GET_RESERVATION_ERROR', err.message));
+    }
+    if (!row) {
+      return next(new ApiError(404, 'Reserva não encontrada', 'RESERVATION_NOT_FOUND'));
+    }
+    res.json(row);
+  });
+});
+
+// Create reservation
+router.post('/', (req, res, next) => {
+  const { restauranteId, eventoId, data, horario, numeroPessoas } = req.body;
+  if (!isValidInt(restauranteId) || !isValidDate(data) || !isValidTime(horario) || !isValidInt(numeroPessoas)) {
+    return next(new ApiError(400, 'Dados inválidos para criação de reserva', 'INVALID_FIELDS'));
+  }
+  const db = getDatabase();
+  db.run(
+    'INSERT INTO reservas (restaurante_id, evento_id, data, horario, numero_pessoas) VALUES (?, ?, ?, ?, ?) RETURNING id',
+    [restauranteId, eventoId || null, data, horario, numeroPessoas],
+    function(err) {
+      if (err) {
+        console.error('❌ Erro ao criar reserva:', err.message);
+        return next(new ApiError(500, 'Erro ao criar reserva', 'CREATE_RESERVATION_ERROR', err.message));
+      }
+      res.status(201).json({ id: this.lastID, restauranteId, eventoId: eventoId || null, data, horario, numeroPessoas });
+    }
+  );
+});
+
+// Update reservation
+router.put('/:id', (req, res, next) => {
+  if (!isValidInt(req.params.id)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  const { restauranteId, eventoId, data, horario, numeroPessoas } = req.body;
+  const fields = [];
+  const values = [];
+  if (restauranteId !== undefined) {
+    if (!isValidInt(restauranteId)) return next(new ApiError(400, 'restauranteId deve ser inteiro', 'INVALID_RESTAURANT_ID'));
+    fields.push('restaurante_id = ?'); values.push(restauranteId);
+  }
+  if (eventoId !== undefined) {
+    if (eventoId !== null && !isValidInt(eventoId)) return next(new ApiError(400, 'eventoId deve ser inteiro', 'INVALID_EVENT_ID'));
+    fields.push('evento_id = ?'); values.push(eventoId);
+  }
+  if (data) {
+    if (!isValidDate(data)) return next(new ApiError(400, 'Data inválida', 'INVALID_DATE'));
+    fields.push('data = ?'); values.push(data);
+  }
+  if (horario) {
+    if (!isValidTime(horario)) return next(new ApiError(400, 'Horário inválido', 'INVALID_TIME'));
+    fields.push('horario = ?'); values.push(horario);
+  }
+  if (numeroPessoas !== undefined) {
+    if (!isValidInt(numeroPessoas)) return next(new ApiError(400, 'numeroPessoas deve ser inteiro', 'INVALID_PEOPLE_NUMBER'));
+    fields.push('numero_pessoas = ?'); values.push(numeroPessoas);
+  }
+  if (fields.length === 0) {
+    return next(new ApiError(400, 'Nenhum dado para atualizar', 'NO_FIELDS_TO_UPDATE'));
+  }
+  values.push(req.params.id);
+  const sql = `UPDATE reservas SET ${fields.join(', ')} WHERE id = ?`;
+  const db = getDatabase();
+  db.run(sql, values, function(err) {
+    if (err) {
+      console.error('❌ Erro ao atualizar reserva:', err.message);
+      return next(new ApiError(500, 'Erro ao atualizar reserva', 'UPDATE_RESERVATION_ERROR', err.message));
+    }
+    if (this.changes === 0) {
+      return next(new ApiError(404, 'Reserva não encontrada', 'RESERVATION_NOT_FOUND'));
+    }
+    res.json({ message: 'Reserva atualizada com sucesso' });
+  });
+});
+
+// Delete reservation
+router.delete('/:id', (req, res, next) => {
+  if (!isValidInt(req.params.id)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  const db = getDatabase();
+  db.run('DELETE FROM reservas WHERE id = ?', [req.params.id], function(err) {
+    if (err) {
+      console.error('❌ Erro ao deletar reserva:', err.message);
+      return next(new ApiError(500, 'Erro ao deletar reserva', 'DELETE_RESERVATION_ERROR', err.message));
+    }
+    if (this.changes === 0) {
+      return next(new ApiError(404, 'Reserva não encontrada', 'RESERVATION_NOT_FOUND'));
+    }
+    res.json({ message: 'Reserva deletada com sucesso' });
+  });
+});
+
+module.exports = router;

--- a/backend/routes/restaurantes.js
+++ b/backend/routes/restaurantes.js
@@ -1,0 +1,114 @@
+const express = require('express');
+const { getDatabase } = require('../config/database');
+const { ApiError } = require('../middleware/errorHandler');
+
+const router = express.Router();
+
+function isValidInt(value) {
+  return Number.isInteger(Number(value));
+}
+
+// List all restaurants
+router.get('/', (req, res, next) => {
+  const db = getDatabase();
+  db.all('SELECT id, nome, endereco, capacidade FROM restaurantes', [], (err, rows) => {
+    if (err) {
+      console.error('❌ Erro ao listar restaurantes:', err.message);
+      return next(new ApiError(500, 'Erro ao listar restaurantes', 'LIST_RESTAURANTS_ERROR', err.message));
+    }
+    res.json(rows);
+  });
+});
+
+// Get single restaurant
+router.get('/:id', (req, res, next) => {
+  if (!isValidInt(req.params.id)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  const db = getDatabase();
+  db.get('SELECT id, nome, endereco, capacidade FROM restaurantes WHERE id = ?', [req.params.id], (err, row) => {
+    if (err) {
+      console.error('❌ Erro ao obter restaurante:', err.message);
+      return next(new ApiError(500, 'Erro ao obter restaurante', 'GET_RESTAURANT_ERROR', err.message));
+    }
+    if (!row) {
+      return next(new ApiError(404, 'Restaurante não encontrado', 'RESTAURANT_NOT_FOUND'));
+    }
+    res.json(row);
+  });
+});
+
+// Create restaurant
+router.post('/', (req, res, next) => {
+  const { nome, endereco, capacidade } = req.body;
+  if (!nome || !endereco || !isValidInt(capacidade)) {
+    return next(new ApiError(400, 'Nome, endereço e capacidade inteira são obrigatórios', 'MISSING_FIELDS'));
+  }
+  const db = getDatabase();
+  db.run(
+    'INSERT INTO restaurantes (nome, endereco, capacidade) VALUES (?, ?, ?) RETURNING id',
+    [nome, endereco, capacidade],
+    function(err) {
+      if (err) {
+        console.error('❌ Erro ao criar restaurante:', err.message);
+        return next(new ApiError(500, 'Erro ao criar restaurante', 'CREATE_RESTAURANT_ERROR', err.message));
+      }
+      res.status(201).json({ id: this.lastID, nome, endereco, capacidade });
+    }
+  );
+});
+
+// Update restaurant
+router.put('/:id', (req, res, next) => {
+  if (!isValidInt(req.params.id)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  const { nome, endereco, capacidade } = req.body;
+  const fields = [];
+  const values = [];
+  if (nome) { fields.push('nome = ?'); values.push(nome); }
+  if (endereco) { fields.push('endereco = ?'); values.push(endereco); }
+  if (capacidade !== undefined) {
+    if (!isValidInt(capacidade)) {
+      return next(new ApiError(400, 'Capacidade deve ser um inteiro', 'INVALID_CAPACITY'));
+    }
+    fields.push('capacidade = ?');
+    values.push(capacidade);
+  }
+  if (fields.length === 0) {
+    return next(new ApiError(400, 'Nenhum dado para atualizar', 'NO_FIELDS_TO_UPDATE'));
+  }
+  values.push(req.params.id);
+  const sql = `UPDATE restaurantes SET ${fields.join(', ')} WHERE id = ?`;
+  const db = getDatabase();
+  db.run(sql, values, function(err) {
+    if (err) {
+      console.error('❌ Erro ao atualizar restaurante:', err.message);
+      return next(new ApiError(500, 'Erro ao atualizar restaurante', 'UPDATE_RESTAURANT_ERROR', err.message));
+    }
+    if (this.changes === 0) {
+      return next(new ApiError(404, 'Restaurante não encontrado', 'RESTAURANT_NOT_FOUND'));
+    }
+    res.json({ message: 'Restaurante atualizado com sucesso' });
+  });
+});
+
+// Delete restaurant
+router.delete('/:id', (req, res, next) => {
+  if (!isValidInt(req.params.id)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  const db = getDatabase();
+  db.run('DELETE FROM restaurantes WHERE id = ?', [req.params.id], function(err) {
+    if (err) {
+      console.error('❌ Erro ao deletar restaurante:', err.message);
+      return next(new ApiError(500, 'Erro ao deletar restaurante', 'DELETE_RESTAURANT_ERROR', err.message));
+    }
+    if (this.changes === 0) {
+      return next(new ApiError(404, 'Restaurante não encontrado', 'RESTAURANT_NOT_FOUND'));
+    }
+    res.json({ message: 'Restaurante deletado com sucesso' });
+  });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,6 +17,9 @@ const { ApiError, errorHandler } = require('./middleware/errorHandler');
 const authRoutes = require('./routes/auth');
 const dashboardRoutes = require('./routes/dashboard');
 const usersRoutes = require('./routes/users');
+const restaurantesRoutes = require('./routes/restaurantes');
+const eventosRoutes = require('./routes/eventos');
+const reservasRoutes = require('./routes/reservas');
 
 // Importar middleware de autenticação
 const { authenticateToken } = require('./middleware/auth');
@@ -90,6 +93,9 @@ app.use('/auth', authRoutes);
 // Rotas protegidas (requerem autenticação)
 app.use('/dashboard', authenticateToken, dashboardRoutes);
 app.use('/users', authenticateToken, usersRoutes);
+app.use('/restaurantes', authenticateToken, restaurantesRoutes);
+app.use('/eventos', authenticateToken, eventosRoutes);
+app.use('/reservas', authenticateToken, reservasRoutes);
 
 // Rota para servir arquivos estáticos (se necessário)
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));


### PR DESCRIPTION
## Summary
- implement REST routers for restaurants, events, and reservations with data validation
- register new routers in main server configuration

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68951b1355ec832ea48f6393fffa6d06