### PR TITLE
Add restaurant, event, and reservation tables

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -18,3 +18,32 @@ CREATE TABLE IF NOT EXISTS sessions (
   revoked_at TIMESTAMP,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS restaurantes (
+  id SERIAL PRIMARY KEY,
+  nome VARCHAR(255) NOT NULL,
+  capacidade INTEGER,
+  horario_funcionamento VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS eventos (
+  id SERIAL PRIMARY KEY,
+  nome_evento VARCHAR(255) NOT NULL,
+  data_evento DATE NOT NULL,
+  horario_evento TIME NOT NULL,
+  id_restaurante INTEGER NOT NULL REFERENCES restaurantes(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS reservas (
+  id_reserva SERIAL PRIMARY KEY,
+  nome_hospede VARCHAR(255) NOT NULL,
+  data_checkin DATE NOT NULL,
+  data_checkout DATE NOT NULL,
+  qtd_hospedes INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS eventos_reservas (
+  id_evento INTEGER NOT NULL REFERENCES eventos(id) ON DELETE CASCADE,
+  id_reserva INTEGER NOT NULL REFERENCES reservas(id_reserva) ON DELETE CASCADE,
+  PRIMARY KEY (id_evento, id_reserva)
+);

--- a/backend/database/seed.sql
+++ b/backend/database/seed.sql
@@ -2,3 +2,22 @@
 INSERT INTO users (username, email, password, full_name)
 VALUES ('admin', 'admin@example.com', '$2a$12$.NifCEunTbm0Q7mpJmCS3OsKigZvlwWYNSIRn6lGfasceRI965Y6u', 'Administrador')
 ON CONFLICT (username) DO NOTHING;
+
+INSERT INTO restaurantes (id, nome, capacidade, horario_funcionamento) VALUES
+  (1, 'Restaurante Central', 100, '08:00-22:00'),
+  (2, 'Bistrô da Praça', 50, '10:00-20:00')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO eventos (id, nome_evento, data_evento, horario_evento, id_restaurante) VALUES
+  (1, 'Noite Italiana', '2024-12-15', '19:00', 1)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO reservas (id_reserva, nome_hospede, data_checkin, data_checkout, qtd_hospedes) VALUES
+  (1, 'João Silva', '2024-12-14', '2024-12-16', 2),
+  (2, 'Maria Souza', '2024-12-15', '2024-12-17', 4)
+ON CONFLICT (id_reserva) DO NOTHING;
+
+INSERT INTO eventos_reservas (id_evento, id_reserva) VALUES
+  (1, 1),
+  (1, 2)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- define `restaurantes`, `eventos`, `reservas`, and `eventos_reservas` tables in schema
- seed database with sample restaurants, events, and reservations

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68951b12c080832e8f59cc3ae6b4fe5d