### PR TITLE
Cria tabelas automaticamente no start do servidor

### DIFF
--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -5,6 +5,8 @@
 
 const { Pool } = require('pg');
 const bcrypt = require('bcryptjs');
+const fs = require('fs');
+const path = require('path');
 
 let pool = null;
 
@@ -41,35 +43,12 @@ function convertPlaceholders(sql) {
 }
 
 /**
- * Criar tabelas necessárias
+ * Criar tabelas necessárias carregando o schema do projeto
  */
 async function createTables() {
-  const createUsersTable = `
-    CREATE TABLE IF NOT EXISTS users (
-      id SERIAL PRIMARY KEY,
-      username VARCHAR(255) UNIQUE NOT NULL,
-      email VARCHAR(255) UNIQUE NOT NULL,
-      password VARCHAR(255) NOT NULL,
-      full_name VARCHAR(255),
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-      is_active INTEGER DEFAULT 1
-    )
-  `;
-
-  const createSessionsTable = `
-    CREATE TABLE IF NOT EXISTS sessions (
-      id SERIAL PRIMARY KEY,
-      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      token_hash TEXT NOT NULL,
-      expires_at TIMESTAMP NOT NULL,
-      revoked_at TIMESTAMP,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    )
-  `;
-
-  await pool.query(createUsersTable);
-  await pool.query(createSessionsTable);
+  const schemaPath = path.join(__dirname, '../database/schema.sql');
+  const schema = fs.readFileSync(schemaPath, 'utf8');
+  await pool.query(schema);
   console.log('✅ Tabelas criadas/verificadas');
 }
 


### PR DESCRIPTION
## Summary
- Executa todo o `schema.sql` em uma única consulta para garantir a criação de todas as tabelas necessárias

## Testing
- `npm test` (falha: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_6895211e63a0832e9502f6c08ed2c9d4