### PR TITLE
Remove endereco from restaurant CRUD

### DIFF
--- a/frontend/src/app/components/restaurantes/restaurante-form.html
+++ b/frontend/src/app/components/restaurantes/restaurante-form.html
@@ -7,9 +7,15 @@
     </div>
 
     <div class="field">
-      <label for="localizacao">Localização</label>
-      <input id="localizacao" type="text" pInputText formControlName="localizacao" />
-      <div class="error" *ngIf="form.get('localizacao')?.hasError('required') && form.get('localizacao')?.touched">Localização é obrigatória.</div>
+      <label for="capacidade">Capacidade</label>
+      <input id="capacidade" type="number" pInputText formControlName="capacidade" />
+      <div class="error" *ngIf="form.get('capacidade')?.hasError('required') && form.get('capacidade')?.touched">Capacidade é obrigatória.</div>
+    </div>
+
+    <div class="field">
+      <label for="horarioFuncionamento">Horário de Funcionamento</label>
+      <input id="horarioFuncionamento" type="text" pInputText formControlName="horarioFuncionamento" />
+      <div class="error" *ngIf="form.get('horarioFuncionamento')?.hasError('required') && form.get('horarioFuncionamento')?.touched">Horário de funcionamento é obrigatório.</div>
     </div>
 
     <div class="actions">

--- a/frontend/src/app/components/restaurantes/restaurante-form.ts
+++ b/frontend/src/app/components/restaurantes/restaurante-form.ts
@@ -40,7 +40,8 @@ export class RestauranteFormComponent implements OnInit {
   ) {
     this.form = this.fb.group({
       nome: ['', Validators.required],
-      localizacao: ['', Validators.required]
+      capacidade: [null, Validators.required],
+      horarioFuncionamento: ['', Validators.required]
     });
   }
 

--- a/frontend/src/app/components/restaurantes/restaurante-list.html
+++ b/frontend/src/app/components/restaurantes/restaurante-list.html
@@ -13,14 +13,16 @@
     <ng-template pTemplate="header">
       <tr>
         <th>Nome</th>
-        <th>Localização</th>
+        <th>Capacidade</th>
+        <th>Horário de Funcionamento</th>
         <th>Ações</th>
       </tr>
     </ng-template>
     <ng-template pTemplate="body" let-r>
       <tr>
         <td>{{ r.nome }}</td>
-        <td>{{ r.localizacao }}</td>
+        <td>{{ r.capacidade }}</td>
+        <td>{{ r.horarioFuncionamento }}</td>
         <td>
           <button pButton icon="pi pi-pencil" class="p-button-text" (click)="editar(r.id)"></button>
           <button pButton icon="pi pi-trash" class="p-button-text p-button-danger" (click)="excluir(r.id)"></button>

--- a/frontend/src/app/models/restaurante.ts
+++ b/frontend/src/app/models/restaurante.ts
@@ -4,7 +4,6 @@
 export interface Restaurante {
   id?: number;
   nome: string;
-  descricao?: string;
-  endereco?: string;
   capacidade?: number;
+  horario_funcionamento?: string;
 }

--- a/frontend/src/app/services/restaurantes.ts
+++ b/frontend/src/app/services/restaurantes.ts
@@ -11,7 +11,8 @@ import { Observable, catchError, throwError, map } from 'rxjs';
 export interface Restaurante {
   id?: number;
   nome: string;
-  localizacao: string;
+  capacidade: number;
+  horarioFuncionamento: string;
 }
 
 @Injectable({
@@ -25,7 +26,12 @@ export class RestauranteService {
   getRestaurantes(page = 1, limit = 10): Observable<{ data: Restaurante[]; total: number }> {
     return this.http.get<any>(`${this.API_URL}/restaurantes`, { params: { page, limit } }).pipe(
       map(res => ({
-        data: res.data.map((r: any) => ({ id: r.id, nome: r.nome, localizacao: r.endereco } as Restaurante)),
+        data: res.data.map((r: any) => ({
+          id: r.id,
+          nome: r.nome,
+          capacidade: r.capacidade,
+          horarioFuncionamento: r.horario_funcionamento
+        } as Restaurante)),
         total: res.total
       })),
       catchError(error => {
@@ -37,7 +43,12 @@ export class RestauranteService {
 
   getRestaurante(id: number): Observable<Restaurante> {
     return this.http.get<any>(`${this.API_URL}/restaurantes/${id}`).pipe(
-      map(r => ({ id: r.id, nome: r.nome, localizacao: r.endereco } as Restaurante)),
+      map(r => ({
+        id: r.id,
+        nome: r.nome,
+        capacidade: r.capacidade,
+        horarioFuncionamento: r.horario_funcionamento
+      } as Restaurante)),
       catchError(error => {
         console.error('❌ Erro ao obter restaurante:', error);
         return throwError(() => error);
@@ -46,7 +57,11 @@ export class RestauranteService {
   }
 
   createRestaurante(data: Restaurante): Observable<any> {
-    const payload = { nome: data.nome, endereco: data.localizacao };
+    const payload = {
+      nome: data.nome,
+      capacidade: data.capacidade,
+      horario_funcionamento: data.horarioFuncionamento
+    };
     return this.http.post(`${this.API_URL}/restaurantes`, payload).pipe(
       catchError(error => {
         console.error('❌ Erro ao criar restaurante:', error);
@@ -57,9 +72,9 @@ export class RestauranteService {
 
   updateRestaurante(id: number, data: Partial<Restaurante>): Observable<any> {
     const payload: any = { ...data };
-    if (data.localizacao !== undefined) {
-      payload.endereco = data.localizacao;
-      delete payload.localizacao;
+    if (data.horarioFuncionamento !== undefined) {
+      payload.horario_funcionamento = data.horarioFuncionamento;
+      delete payload.horarioFuncionamento;
     }
     return this.http.put(`${this.API_URL}/restaurantes/${id}`, payload).pipe(
       catchError(error => {


### PR DESCRIPTION
## Summary
- replace endereco with horario_funcionamento in restaurant API
- add capacidade and horario fields to restaurant forms and lists

## Testing
- `npm test`
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895287c0dc8832ea644847eb8474c45