### PR TITLE
feat: add global error interceptor

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -3,17 +3,20 @@ import { provideRouter } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { providePrimeNG } from 'primeng/config';
+import { MessageService } from 'primeng/api';
 import Aura from '@primeuix/themes/aura';
 import { routes } from './app.routes';
 import { authInterceptor } from './interceptors/auth-interceptor';
+import { errorInterceptor } from './interceptors/error-interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient(withInterceptors([authInterceptor])),
+    provideHttpClient(withInterceptors([authInterceptor, errorInterceptor])),
     provideAnimationsAsync(),
-    providePrimeNG({ theme: { preset: Aura, options: { darkModeSelector: '.app-dark' } } })
+    providePrimeNG({ theme: { preset: Aura, options: { darkModeSelector: '.app-dark' } } }),
+    MessageService
   ]
 };

--- a/frontend/src/app/components/change-password/change-password.ts
+++ b/frontend/src/app/components/change-password/change-password.ts
@@ -33,11 +33,8 @@ export class ChangePasswordComponent {
         this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Senha alterada com sucesso' });
         setTimeout(() => this.router.navigate(['/dashboard']), 1000);
       },
-      error: (err) => {
+      error: () => {
         this.isLoading = false;
-        let msg = 'Erro ao trocar senha';
-        if (err.error?.error) { msg = err.error.error; }
-        this.messageService.add({ severity: 'error', summary: 'Erro', detail: msg });
       }
     });
   }

--- a/frontend/src/app/components/dashboard/dashboard.ts
+++ b/frontend/src/app/components/dashboard/dashboard.ts
@@ -86,12 +86,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       error: (error) => {
         this.isLoading = false;
         console.error('Erro ao carregar dashboard:', error);
-
-        this.messageService.add({
-          severity: 'error',
-          summary: 'Erro',
-          detail: 'Erro ao carregar dados do dashboard'
-        });
       }
     });
   }

--- a/frontend/src/app/components/eventos/evento-form.ts
+++ b/frontend/src/app/components/eventos/evento-form.ts
@@ -51,8 +51,7 @@ export class EventoFormComponent implements OnInit {
       this.id = Number(idParam);
       this.isEdit = true;
       this.service.getEvento(this.id).subscribe({
-        next: data => this.form.patchValue(data),
-        error: err => this.showError('Erro ao carregar evento', err)
+        next: data => this.form.patchValue(data)
       });
     }
   }
@@ -75,9 +74,8 @@ export class EventoFormComponent implements OnInit {
         this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Evento salvo' });
         this.router.navigate(['/eventos']);
       },
-      error: err => {
+      error: () => {
         this.isLoading = false;
-        this.showError('Erro ao salvar evento', err);
       }
     });
   }
@@ -86,11 +84,4 @@ export class EventoFormComponent implements OnInit {
     this.router.navigate(['/eventos']);
   }
 
-  private showError(summary: string, err: any): void {
-    let detail = 'Falha na operação';
-    if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Dados inválidos';
-    }
-    this.messageService.add({ severity: 'error', summary, detail });
-  }
 }

--- a/frontend/src/app/components/eventos/evento-list.ts
+++ b/frontend/src/app/components/eventos/evento-list.ts
@@ -50,9 +50,8 @@ export class EventoListComponent implements OnInit {
         this.totalRecords = res.total;
         this.isLoading = false;
       },
-      error: err => {
+      error: () => {
         this.isLoading = false;
-        this.showError('Erro ao carregar eventos', err);
       }
     });
   }
@@ -79,16 +78,7 @@ export class EventoListComponent implements OnInit {
       next: () => {
         this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Evento removido' });
         this.load();
-      },
-      error: err => this.showError('Erro ao remover evento', err)
+      }
     });
-  }
-
-  private showError(summary: string, err: any): void {
-    let detail = 'Falha na operação';
-    if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Requisição inválida';
-    }
-    this.messageService.add({ severity: 'error', summary, detail });
   }
 }

--- a/frontend/src/app/components/login/login.ts
+++ b/frontend/src/app/components/login/login.ts
@@ -44,7 +44,6 @@ export class LoginComponent implements OnInit {
   };
 
   isLoading = false;
-  errorMessage = '';
   returnUrl = '/dashboard';
 
   constructor(
@@ -71,7 +70,6 @@ export class LoginComponent implements OnInit {
     }
 
     this.isLoading = true;
-    this.errorMessage = '';
 
     this.authService.login(this.credentials).subscribe({
       next: (response) => {
@@ -88,26 +86,13 @@ export class LoginComponent implements OnInit {
           this.router.navigate([this.returnUrl]);
         }, 1000);
       },
-      error: (error) => {
+      error: () => {
         this.isLoading = false;
-        
-        let errorMsg = 'Erro ao fazer login. Tente novamente.';
-        
-        if (error.error?.error) {
-          errorMsg = error.error.error;
-        } else if (error.status === 401) {
-          errorMsg = 'Credenciais inválidas. Verifique seu usuário e senha.';
-        } else if (error.status === 0) {
-          errorMsg = 'Erro de conexão. Verifique se o servidor está rodando.';
-        }
-        
-        this.showError(errorMsg);
       }
     });
   }
 
   private showError(message: string): void {
-    this.errorMessage = message;
     this.messageService.add({
       severity: 'error',
       summary: 'Erro',

--- a/frontend/src/app/components/reserva-evento/reserva-evento.ts
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.ts
@@ -52,13 +52,11 @@ export class ReservaEventoComponent implements OnInit {
     };
 
     this.reservaEventoService.getReservas(filtros).subscribe({
-      next: data => (this.reservas = data),
-      error: () => this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao carregar reservas' })
+      next: data => (this.reservas = data)
     });
 
     this.reservaEventoService.getEventos(filtros).subscribe({
-      next: data => (this.eventos = data),
-      error: () => this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao carregar eventos' })
+      next: data => (this.eventos = data)
     });
   }
 
@@ -74,18 +72,6 @@ export class ReservaEventoComponent implements OnInit {
         next: () => {
           this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Reserva vinculada ao evento' });
           this.carregarDados();
-        },
-        error: err => {
-          let detail = 'Falha ao vincular reserva';
-          const msg = err.error?.message || '';
-          if (msg.toLowerCase().includes('capacidade')) {
-            detail = 'Capacidade do evento excedida';
-          } else if (msg.toLowerCase().includes('restaurante')) {
-            detail = 'Não é permitido múltiplos restaurantes no mesmo dia';
-          } else if (msg.toLowerCase().includes('duração')) {
-            detail = 'Limite de eventos por duração excedido';
-          }
-          this.messageService.add({ severity: 'error', summary: 'Erro', detail });
         }
       });
   }

--- a/frontend/src/app/components/reservas/reserva-form.ts
+++ b/frontend/src/app/components/reservas/reserva-form.ts
@@ -55,8 +55,7 @@ export class ReservaFormComponent implements OnInit {
       this.id = Number(idParam);
       this.isEdit = true;
       this.service.getReserva(this.id).subscribe({
-        next: data => this.form.patchValue(data),
-        error: err => this.showError('Erro ao carregar reserva', err)
+        next: data => this.form.patchValue(data)
       });
     }
   }
@@ -79,9 +78,8 @@ export class ReservaFormComponent implements OnInit {
         this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Reserva salva' });
         this.router.navigate(['/reservas']);
       },
-      error: err => {
+      error: () => {
         this.isLoading = false;
-        this.showError('Erro ao salvar reserva', err);
       }
     });
   }
@@ -90,11 +88,4 @@ export class ReservaFormComponent implements OnInit {
     this.router.navigate(['/reservas']);
   }
 
-  private showError(summary: string, err: any): void {
-    let detail = 'Falha na operação';
-    if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Dados inválidos';
-    }
-    this.messageService.add({ severity: 'error', summary, detail });
-  }
 }

--- a/frontend/src/app/components/reservas/reserva-list.ts
+++ b/frontend/src/app/components/reservas/reserva-list.ts
@@ -48,9 +48,8 @@ export class ReservaListComponent implements OnInit {
         this.totalRecords = res.total;
         this.isLoading = false;
       },
-      error: err => {
+      error: () => {
         this.isLoading = false;
-        this.showError('Erro ao carregar reservas', err);
       }
     });
   }
@@ -77,16 +76,7 @@ export class ReservaListComponent implements OnInit {
       next: () => {
         this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Reserva removida' });
         this.load();
-      },
-      error: err => this.showError('Erro ao remover reserva', err)
+      }
     });
-  }
-
-  private showError(summary: string, err: any): void {
-    let detail = 'Falha na operação';
-    if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Requisição inválida';
-    }
-    this.messageService.add({ severity: 'error', summary, detail });
   }
 }

--- a/frontend/src/app/components/reset-password/reset-password.ts
+++ b/frontend/src/app/components/reset-password/reset-password.ts
@@ -50,11 +50,8 @@ export class ResetPasswordComponent {
         this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Senha redefinida com sucesso' });
         setTimeout(() => this.router.navigate(['/login']), 1000);
       },
-      error: (err) => {
+      error: () => {
         this.isLoading = false;
-        let msg = 'Erro ao redefinir senha';
-        if (err.error?.error) { msg = err.error.error; }
-        this.messageService.add({ severity: 'error', summary: 'Erro', detail: msg });
       }
     });
   }

--- a/frontend/src/app/components/restaurantes/restaurante-form.ts
+++ b/frontend/src/app/components/restaurantes/restaurante-form.ts
@@ -51,8 +51,7 @@ export class RestauranteFormComponent implements OnInit {
       this.id = Number(idParam);
       this.isEdit = true;
       this.service.getRestaurante(this.id).subscribe({
-        next: data => this.form.patchValue(data),
-        error: err => this.showError('Erro ao carregar restaurante', err)
+        next: data => this.form.patchValue(data)
       });
     }
   }
@@ -75,9 +74,8 @@ export class RestauranteFormComponent implements OnInit {
         this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Restaurante salvo' });
         this.router.navigate(['/restaurantes']);
       },
-      error: err => {
+      error: () => {
         this.isLoading = false;
-        this.showError('Erro ao salvar restaurante', err);
       }
     });
   }
@@ -86,11 +84,4 @@ export class RestauranteFormComponent implements OnInit {
     this.router.navigate(['/restaurantes']);
   }
 
-  private showError(summary: string, err: any): void {
-    let detail = 'Falha na operação';
-    if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Dados inválidos';
-    }
-    this.messageService.add({ severity: 'error', summary, detail });
-  }
 }

--- a/frontend/src/app/components/restaurantes/restaurante-list.ts
+++ b/frontend/src/app/components/restaurantes/restaurante-list.ts
@@ -50,9 +50,8 @@ export class RestauranteListComponent implements OnInit {
         this.totalRecords = res.total;
         this.isLoading = false;
       },
-      error: err => {
+      error: () => {
         this.isLoading = false;
-        this.showError('Erro ao carregar restaurantes', err);
       }
     });
   }
@@ -79,16 +78,7 @@ export class RestauranteListComponent implements OnInit {
       next: () => {
         this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Restaurante removido' });
         this.load();
-      },
-      error: err => this.showError('Erro ao remover restaurante', err)
+      }
     });
-  }
-
-  private showError(summary: string, err: any): void {
-    let detail = 'Falha na operação';
-    if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Requisição inválida';
-    }
-    this.messageService.add({ severity: 'error', summary, detail });
   }
 }

--- a/frontend/src/app/components/users/user-form.ts
+++ b/frontend/src/app/components/users/user-form.ts
@@ -57,7 +57,6 @@ export class UserFormComponent implements OnInit {
         } as AppUser;
       },
       error: () => {
-        this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Usuário não encontrado' });
         this.router.navigate(['/users']);
       }
     });
@@ -88,9 +87,8 @@ export class UserFormComponent implements OnInit {
         this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Usuário salvo' });
         this.router.navigate(['/users']);
       },
-      error: err => {
+      error: () => {
         this.isLoading = false;
-        this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao salvar usuário' });
       }
     });
   }

--- a/frontend/src/app/components/users/user-list.ts
+++ b/frontend/src/app/components/users/user-list.ts
@@ -46,9 +46,8 @@ export class UserListComponent implements OnInit {
         this.totalRecords = res.total;
         this.isLoading = false;
       },
-      error: err => {
+      error: () => {
         this.isLoading = false;
-        this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao carregar usuários' });
       }
     });
   }
@@ -78,10 +77,6 @@ export class UserListComponent implements OnInit {
           const detail = user.is_active ? 'Usuário desativado' : 'Usuário reativado';
           this.messageService.add({ severity: 'success', summary: 'Sucesso', detail });
           this.loadUsers();
-        },
-        error: () => {
-          const detail = user.is_active ? 'Falha ao desativar usuário' : 'Falha ao reativar usuário';
-          this.messageService.add({ severity: 'error', summary: 'Erro', detail });
         }
       });
   }

--- a/frontend/src/app/interceptors/error-interceptor.ts
+++ b/frontend/src/app/interceptors/error-interceptor.ts
@@ -1,0 +1,16 @@
+import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { MessageService } from 'primeng/api';
+import { catchError, throwError } from 'rxjs';
+
+export const errorInterceptor: HttpInterceptorFn = (req, next) => {
+  const messageService = inject(MessageService);
+
+  return next(req).pipe(
+    catchError((err: HttpErrorResponse) => {
+      const detail = err.error?.error || err.error?.message || 'Erro desconhecido';
+      messageService.add({ severity: 'error', summary: 'Erro', detail });
+      return throwError(() => err);
+    })
+  );
+};


### PR DESCRIPTION
## Summary
- add HTTP error interceptor that shows toast messages
- register error interceptor and PrimeNG MessageService
- remove component-level error toasts now handled globally

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68953a43be18832ea8fa9442b3ce5f78