### PR TITLE
Padroniza tratamento de erros no frontend

### DIFF
--- a/frontend/src/app/components/eventos/evento-form.ts
+++ b/frontend/src/app/components/eventos/evento-form.ts
@@ -16,6 +16,7 @@ import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { EventoService, Evento } from '../../services/eventos';
+import { extractErrorMessage } from '../../utils';
 
 @Component({
   selector: 'app-evento-form',
@@ -89,7 +90,7 @@ export class EventoFormComponent implements OnInit {
   private showError(summary: string, err: any): void {
     let detail = 'Falha na operação';
     if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Dados inválidos';
+      detail = extractErrorMessage(err);
     }
     this.messageService.add({ severity: 'error', summary, detail });
   }

--- a/frontend/src/app/components/eventos/evento-list.ts
+++ b/frontend/src/app/components/eventos/evento-list.ts
@@ -16,6 +16,7 @@ import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { EventoService, Evento } from '../../services/eventos';
+import { extractErrorMessage } from '../../utils';
 
 @Component({
   selector: 'app-evento-list',
@@ -87,7 +88,7 @@ export class EventoListComponent implements OnInit {
   private showError(summary: string, err: any): void {
     let detail = 'Falha na operação';
     if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Requisição inválida';
+      detail = extractErrorMessage(err);
     }
     this.messageService.add({ severity: 'error', summary, detail });
   }

--- a/frontend/src/app/components/reserva-evento/reserva-evento.ts
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.ts
@@ -16,6 +16,7 @@ import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { ReservaEventoService, Reserva, Evento } from '../../services/reserva-evento';
+import { extractErrorMessage } from '../../utils';
 
 @Component({
   selector: 'app-reserva-evento',
@@ -77,7 +78,7 @@ export class ReservaEventoComponent implements OnInit {
         },
         error: err => {
           let detail = 'Falha ao vincular reserva';
-          const msg = err.error?.message || '';
+          const msg = extractErrorMessage(err);
           if (msg.toLowerCase().includes('capacidade')) {
             detail = 'Capacidade do evento excedida';
           } else if (msg.toLowerCase().includes('restaurante')) {

--- a/frontend/src/app/components/reservas/reserva-form.ts
+++ b/frontend/src/app/components/reservas/reserva-form.ts
@@ -16,6 +16,7 @@ import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { ReservaService, Reserva } from '../../services/reservas';
+import { extractErrorMessage } from '../../utils';
 
 @Component({
   selector: 'app-reserva-form',
@@ -93,7 +94,7 @@ export class ReservaFormComponent implements OnInit {
   private showError(summary: string, err: any): void {
     let detail = 'Falha na operação';
     if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Dados inválidos';
+      detail = extractErrorMessage(err);
     }
     this.messageService.add({ severity: 'error', summary, detail });
   }

--- a/frontend/src/app/components/reservas/reserva-list.ts
+++ b/frontend/src/app/components/reservas/reserva-list.ts
@@ -14,6 +14,7 @@ import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { ReservaService, Reserva } from '../../services/reservas';
+import { extractErrorMessage } from '../../utils';
 
 @Component({
   selector: 'app-reserva-list',
@@ -85,7 +86,7 @@ export class ReservaListComponent implements OnInit {
   private showError(summary: string, err: any): void {
     let detail = 'Falha na operação';
     if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Requisição inválida';
+      detail = extractErrorMessage(err);
     }
     this.messageService.add({ severity: 'error', summary, detail });
   }

--- a/frontend/src/app/components/restaurantes/restaurante-form.ts
+++ b/frontend/src/app/components/restaurantes/restaurante-form.ts
@@ -16,6 +16,7 @@ import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { RestauranteService, Restaurante } from '../../services/restaurantes';
+import { extractErrorMessage } from '../../utils';
 
 @Component({
   selector: 'app-restaurante-form',
@@ -89,7 +90,7 @@ export class RestauranteFormComponent implements OnInit {
   private showError(summary: string, err: any): void {
     let detail = 'Falha na operação';
     if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Dados inválidos';
+      detail = extractErrorMessage(err);
     }
     this.messageService.add({ severity: 'error', summary, detail });
   }

--- a/frontend/src/app/components/restaurantes/restaurante-list.ts
+++ b/frontend/src/app/components/restaurantes/restaurante-list.ts
@@ -16,6 +16,7 @@ import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 
 import { RestauranteService, Restaurante } from '../../services/restaurantes';
+import { extractErrorMessage } from '../../utils';
 
 @Component({
   selector: 'app-restaurante-list',
@@ -87,7 +88,7 @@ export class RestauranteListComponent implements OnInit {
   private showError(summary: string, err: any): void {
     let detail = 'Falha na operação';
     if (err.status >= 400 && err.status < 500) {
-      detail = err.error?.message || 'Requisição inválida';
+      detail = extractErrorMessage(err);
     }
     this.messageService.add({ severity: 'error', summary, detail });
   }

--- a/frontend/src/app/utils/index.ts
+++ b/frontend/src/app/utils/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Extrai uma mensagem de erro padronizada a partir de um objeto de erro.
+ */
+export function extractErrorMessage(err: any): string {
+  return err?.error?.error || err?.error?.message || 'Mensagem padrão';
+}


### PR DESCRIPTION
## Summary
- Adiciona helper `extractErrorMessage` para unificar mensagens de erro
- Atualiza componentes de reservas, eventos e restaurantes para usar o helper

## Testing
- `npm test` *(falhou: Missing script "test")*
- `npm run build` *(falhou: Can't bind to 'value' since it isn't a known property of 'p-table')*


------
https://chatgpt.com/codex/tasks/task_e_68953a447418832e8a52c23dbf506890