### PR TITLE
Disallow password updates via user edit

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -101,6 +101,9 @@ router.post('/', async (req, res, next) => {
 router.put('/:id', async (req, res, next) => {
   try {
     const { username, email, password, fullName, is_active } = req.body;
+    if (password) {
+      return next(new ApiError(400, 'Senha não pode ser alterada por este endpoint', 'PASSWORD_EDIT_FORBIDDEN'));
+    }
     const db = getDatabase();
     db.get('SELECT id FROM users WHERE id = ?', [req.params.id], async (err, user) => {
       if (err) {
@@ -119,11 +122,6 @@ router.put('/:id', async (req, res, next) => {
         const isActiveInt = (is_active === true || is_active === 'true' || is_active === 1 || is_active === '1') ? 1 : 0;
         fields.push('is_active = ?');
         values.push(isActiveInt);
-      }
-      if (password) {
-        const hashed = await bcrypt.hash(password, 12);
-        fields.push('password = ?');
-        values.push(hashed);
       }
       if (fields.length === 0) {
         return next(new ApiError(400, 'Nenhum dado para atualizar', 'NO_FIELDS_TO_UPDATE'));

--- a/frontend/src/app/components/users/user-form.ts
+++ b/frontend/src/app/components/users/user-form.ts
@@ -60,6 +60,7 @@ export class UserFormComponent implements OnInit {
     if (idParam) {
       this.isEdit = true;
       this.userId = Number(idParam);
+      this.form.removeControl('password');
       this.loadUser(this.userId);
     }
   }

--- a/frontend/src/app/services/users.ts
+++ b/frontend/src/app/services/users.ts
@@ -66,7 +66,8 @@ export class UserService {
   }
 
   updateUser(id: number, data: Partial<AppUser>): Observable<any> {
-    return this.http.put(`${this.API_URL}/users/${id}`, data).pipe(
+    const { password, ...payload } = data;
+    return this.http.put(`${this.API_URL}/users/${id}`, payload).pipe(
       catchError(error => {
         console.error('❌ Erro ao atualizar usuário:', error);
         return throwError(() => error);


### PR DESCRIPTION
## Summary
- Reject password changes on user update API
- Strip password field in user edit form and service

## Testing
- `cd backend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68953f78089c832ebb269f2e209952fb