### PR TITLE
Prevent duplicate events for same restaurant

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS eventos (
   nome_evento VARCHAR(255) NOT NULL,
   data_evento DATE NOT NULL,
   horario_evento TIME NOT NULL,
-  id_restaurante INTEGER NOT NULL REFERENCES restaurantes(id) ON DELETE CASCADE
+  id_restaurante INTEGER NOT NULL REFERENCES restaurantes(id) ON DELETE CASCADE,
+  UNIQUE (data_evento, horario_evento, id_restaurante)
 );
 
 CREATE TABLE IF NOT EXISTS reservas (


### PR DESCRIPTION
## Summary
- enforce unique event slot per restaurant by constraining date and time
- check for existing event before inserting to avoid duplicates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm test --prefix backend` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68954b5212d8832e9b24dad27d10c114