### PR TITLE
feat: add reservation search and conflict validation

### DIFF
--- a/backend/routes/reservas.js
+++ b/backend/routes/reservas.js
@@ -16,6 +16,17 @@ function isValidDate(value) {
   return /^\d{4}-\d{2}-\d{2}$/.test(value);
 }
 
+function getOverlaps(db, coduh, checkin, checkout, excludeId, callback) {
+  let sql =
+    'SELECT id, idreservacm, numeroreservacm, coduh, nome_hospede, data_checkin, data_checkout, qtd_hospedes FROM reservas WHERE coduh = ? AND NOT (data_checkout <= ? OR data_checkin >= ?)';
+  const params = [coduh, checkin, checkout];
+  if (excludeId !== undefined) {
+    sql += ' AND id <> ?';
+    params.push(excludeId);
+  }
+  db.all(sql, params, callback);
+}
+
 // List all reservations with pagination
 router.get('/', (req, res, next) => {
   const db = getDatabase();
@@ -40,6 +51,28 @@ router.get('/', (req, res, next) => {
       });
     }
   );
+});
+
+// Search reservation by coduh and period
+router.get('/buscar', (req, res, next) => {
+  const { coduh, checkin, checkout } = req.query;
+  if (!isValidString(coduh) || !isValidDate(checkin) || !isValidDate(checkout)) {
+    return next(new ApiError(400, 'Parâmetros inválidos', 'INVALID_SEARCH_PARAMS'));
+  }
+  const db = getDatabase();
+  getOverlaps(db, coduh, checkin, checkout, undefined, (err, rows) => {
+    if (err) {
+      console.error('❌ Erro ao buscar reserva:', err.message);
+      return next(new ApiError(500, 'Erro ao buscar reserva', 'SEARCH_RESERVATION_ERROR', err.message));
+    }
+    if (rows.length > 1) {
+      return next(new ApiError(409, 'Múltiplas reservas sobrepostas encontradas', 'MULTIPLE_RESERVATIONS'));
+    }
+    if (rows.length === 0) {
+      return next(new ApiError(404, 'Reserva não encontrada', 'RESERVATION_NOT_FOUND'));
+    }
+    res.json(rows[0]);
+  });
 });
 
 // Get single reservation
@@ -75,17 +108,26 @@ router.post('/', (req, res, next) => {
     return next(new ApiError(400, 'Dados inválidos para criação de reserva', 'INVALID_FIELDS'));
   }
   const db = getDatabase();
-  db.run(
-    'INSERT INTO reservas (idreservacm, numeroreservacm, coduh, nome_hospede, data_checkin, data_checkout, qtd_hospedes) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id',
-    [idreservacm, numeroreservacm, coduh, nome_hospede, data_checkin, data_checkout, qtd_hospedes],
-    function(err) {
-      if (err) {
-        console.error('❌ Erro ao criar reserva:', err.message);
-        return next(new ApiError(500, 'Erro ao criar reserva', 'CREATE_RESERVATION_ERROR', err.message));
-      }
-      res.status(201).json({ id: this.lastID, idreservacm, numeroreservacm, coduh, nome_hospede, data_checkin, data_checkout, qtd_hospedes });
+  getOverlaps(db, coduh, data_checkin, data_checkout, undefined, (err, rows) => {
+    if (err) {
+      console.error('❌ Erro ao verificar conflitos:', err.message);
+      return next(new ApiError(500, 'Erro ao verificar conflitos', 'OVERLAP_CHECK_ERROR', err.message));
     }
-  );
+    if (rows.length > 0) {
+      return next(new ApiError(409, 'Período já reservado para este coduh', 'RESERVATION_CONFLICT'));
+    }
+    db.run(
+      'INSERT INTO reservas (idreservacm, numeroreservacm, coduh, nome_hospede, data_checkin, data_checkout, qtd_hospedes) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id',
+      [idreservacm, numeroreservacm, coduh, nome_hospede, data_checkin, data_checkout, qtd_hospedes],
+      function(err2) {
+        if (err2) {
+          console.error('❌ Erro ao criar reserva:', err2.message);
+          return next(new ApiError(500, 'Erro ao criar reserva', 'CREATE_RESERVATION_ERROR', err2.message));
+        }
+        res.status(201).json({ id: this.lastID, idreservacm, numeroreservacm, coduh, nome_hospede, data_checkin, data_checkout, qtd_hospedes });
+      }
+    );
+  });
 });
 
 // Update reservation
@@ -93,52 +135,78 @@ router.put('/:id', (req, res, next) => {
   if (!isValidInt(req.params.id)) {
     return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
   }
-  const { idreservacm, numeroreservacm, coduh, nome_hospede, data_checkin, data_checkout, qtd_hospedes } = req.body;
-  const fields = [];
-  const values = [];
-  if (idreservacm !== undefined) {
-    if (!isValidInt(idreservacm)) return next(new ApiError(400, 'idreservacm deve ser inteiro', 'INVALID_IDRESERVACM'));
-    fields.push('idreservacm = ?'); values.push(idreservacm);
-  }
-  if (numeroreservacm !== undefined) {
-    if (!isValidString(numeroreservacm)) return next(new ApiError(400, 'numeroreservacm inválido', 'INVALID_NUMERORESERVACM'));
-    fields.push('numeroreservacm = ?'); values.push(numeroreservacm);
-  }
-  if (coduh !== undefined) {
-    if (!isValidString(coduh)) return next(new ApiError(400, 'coduh inválido', 'INVALID_CODUH'));
-    fields.push('coduh = ?'); values.push(coduh);
-  }
-  if (nome_hospede !== undefined) {
-    if (!isValidString(nome_hospede)) return next(new ApiError(400, 'nome_hospede inválido', 'INVALID_NOME_HOSPEDE'));
-    fields.push('nome_hospede = ?'); values.push(nome_hospede);
-  }
-  if (data_checkin !== undefined) {
-    if (!isValidDate(data_checkin)) return next(new ApiError(400, 'data_checkin inválida', 'INVALID_DATA_CHECKIN'));
-    fields.push('data_checkin = ?'); values.push(data_checkin);
-  }
-  if (data_checkout !== undefined) {
-    if (!isValidDate(data_checkout)) return next(new ApiError(400, 'data_checkout inválida', 'INVALID_DATA_CHECKOUT'));
-    fields.push('data_checkout = ?'); values.push(data_checkout);
-  }
-  if (qtd_hospedes !== undefined) {
-    if (!isValidInt(qtd_hospedes)) return next(new ApiError(400, 'qtd_hospedes deve ser inteiro', 'INVALID_QTD_HOSPEDES'));
-    fields.push('qtd_hospedes = ?'); values.push(qtd_hospedes);
-  }
-  if (fields.length === 0) {
-    return next(new ApiError(400, 'Nenhum dado para atualizar', 'NO_FIELDS_TO_UPDATE'));
-  }
-  values.push(req.params.id);
-  const sql = `UPDATE reservas SET ${fields.join(', ')} WHERE id = ?`;
   const db = getDatabase();
-  db.run(sql, values, function(err) {
+  db.get('SELECT coduh, data_checkin, data_checkout FROM reservas WHERE id = ?', [req.params.id], (err, existing) => {
     if (err) {
-      console.error('❌ Erro ao atualizar reserva:', err.message);
-      return next(new ApiError(500, 'Erro ao atualizar reserva', 'UPDATE_RESERVATION_ERROR', err.message));
+      console.error('❌ Erro ao obter reserva:', err.message);
+      return next(new ApiError(500, 'Erro ao obter reserva', 'GET_RESERVATION_ERROR', err.message));
     }
-    if (this.changes === 0) {
+    if (!existing) {
       return next(new ApiError(404, 'Reserva não encontrada', 'RESERVATION_NOT_FOUND'));
     }
-    res.json({ message: 'Reserva atualizada com sucesso' });
+
+    const { idreservacm, numeroreservacm, coduh, nome_hospede, data_checkin, data_checkout, qtd_hospedes } = req.body;
+    const fields = [];
+    const values = [];
+
+    let finalCoduh = existing.coduh;
+    let finalCheckin = existing.data_checkin;
+    let finalCheckout = existing.data_checkout;
+
+    if (idreservacm !== undefined) {
+      if (!isValidInt(idreservacm)) return next(new ApiError(400, 'idreservacm deve ser inteiro', 'INVALID_IDRESERVACM'));
+      fields.push('idreservacm = ?'); values.push(idreservacm);
+    }
+    if (numeroreservacm !== undefined) {
+      if (!isValidString(numeroreservacm)) return next(new ApiError(400, 'numeroreservacm inválido', 'INVALID_NUMERORESERVACM'));
+      fields.push('numeroreservacm = ?'); values.push(numeroreservacm);
+    }
+    if (coduh !== undefined) {
+      if (!isValidString(coduh)) return next(new ApiError(400, 'coduh inválido', 'INVALID_CODUH'));
+      fields.push('coduh = ?'); values.push(coduh); finalCoduh = coduh;
+    }
+    if (nome_hospede !== undefined) {
+      if (!isValidString(nome_hospede)) return next(new ApiError(400, 'nome_hospede inválido', 'INVALID_NOME_HOSPEDE'));
+      fields.push('nome_hospede = ?'); values.push(nome_hospede);
+    }
+    if (data_checkin !== undefined) {
+      if (!isValidDate(data_checkin)) return next(new ApiError(400, 'data_checkin inválida', 'INVALID_DATA_CHECKIN'));
+      fields.push('data_checkin = ?'); values.push(data_checkin); finalCheckin = data_checkin;
+    }
+    if (data_checkout !== undefined) {
+      if (!isValidDate(data_checkout)) return next(new ApiError(400, 'data_checkout inválida', 'INVALID_DATA_CHECKOUT'));
+      fields.push('data_checkout = ?'); values.push(data_checkout); finalCheckout = data_checkout;
+    }
+    if (qtd_hospedes !== undefined) {
+      if (!isValidInt(qtd_hospedes)) return next(new ApiError(400, 'qtd_hospedes deve ser inteiro', 'INVALID_QTD_HOSPEDES'));
+      fields.push('qtd_hospedes = ?'); values.push(qtd_hospedes);
+    }
+    if (fields.length === 0) {
+      return next(new ApiError(400, 'Nenhum dado para atualizar', 'NO_FIELDS_TO_UPDATE'));
+    }
+
+    getOverlaps(db, finalCoduh, finalCheckin, finalCheckout, req.params.id, (err2, rows) => {
+      if (err2) {
+        console.error('❌ Erro ao verificar conflitos:', err2.message);
+        return next(new ApiError(500, 'Erro ao verificar conflitos', 'OVERLAP_CHECK_ERROR', err2.message));
+      }
+      if (rows.length > 0) {
+        return next(new ApiError(409, 'Período já reservado para este coduh', 'RESERVATION_CONFLICT'));
+      }
+
+      values.push(req.params.id);
+      const sql = `UPDATE reservas SET ${fields.join(', ')} WHERE id = ?`;
+      db.run(sql, values, function(err3) {
+        if (err3) {
+          console.error('❌ Erro ao atualizar reserva:', err3.message);
+          return next(new ApiError(500, 'Erro ao atualizar reserva', 'UPDATE_RESERVATION_ERROR', err3.message));
+        }
+        if (this.changes === 0) {
+          return next(new ApiError(404, 'Reserva não encontrada', 'RESERVATION_NOT_FOUND'));
+        }
+        res.json({ message: 'Reserva atualizada com sucesso' });
+      });
+    });
   });
 });
 

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -74,6 +74,36 @@
           "401": { "description": "Usuário não autorizado" }
         }
       }
+    },
+    "/reservas/buscar": {
+      "get": {
+        "summary": "Buscar reserva por coduh e período",
+        "parameters": [
+          {
+            "name": "coduh",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "checkin",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "checkout",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "format": "date" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Reserva encontrada" },
+          "404": { "description": "Reserva não encontrada" },
+          "409": { "description": "Múltiplas reservas sobrepostas" }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add GET /reservas/buscar to lookup reservations by coduh and period
- prevent overlapping reservations on create and update
- document reservation search endpoint in swagger

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689563e12fb4832e8c0476b60fe6b10c