### PR TITLE
feat: add event availability reservation

### DIFF
--- a/frontend/src/app/components/reserva-evento/reserva-evento.html
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.html
@@ -1,61 +1,76 @@
 <p-toast></p-toast>
 
-<div class="filters">
-  <p-select [(ngModel)]="filtroRestaurante" [options]="eventos" optionLabel="restaurante" optionValue="restaurante" placeholder="Restaurante"></p-select>
-  <p-select [(ngModel)]="filtroEvento" [options]="eventos" optionLabel="nome" optionValue="id" placeholder="Evento"></p-select>
-  <p-datepicker [(ngModel)]="filtroData" dateFormat="yy-mm-dd" placeholder="Data"></p-datepicker>
-  <button pButton type="button" label="Filtrar" (click)="aplicarFiltros()"></button>
-</div>
+<div class="layout">
+  <div class="left-column">
+    <div class="filters">
+      <p-select [(ngModel)]="filtroRestaurante" [options]="eventos" optionLabel="restaurante" optionValue="restaurante" placeholder="Restaurante"></p-select>
+      <p-select [(ngModel)]="filtroEvento" [options]="eventos" optionLabel="nome" optionValue="id" placeholder="Evento"></p-select>
+      <p-datepicker [(ngModel)]="filtroData" dateFormat="yy-mm-dd" placeholder="Data"></p-datepicker>
+      <button pButton type="button" label="Filtrar" (click)="aplicarFiltros()"></button>
+    </div>
 
-<div class="lists">
-  <h3>Reservas</h3>
-  <p-table [value]="reservas">
-    <ng-template pTemplate="header">
-      <tr>
-        <th>Id Reserva CM</th>
-        <th>Número Reserva CM</th>
-        <th>Código UH</th>
-        <th>Nome Hóspede</th>
-        <th>Check-in</th>
-        <th>Check-out</th>
-        <th>Qtd Hóspedes</th>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="body" let-reserva>
-      <tr>
-        <td>{{ reserva.idreservacm }}</td>
-        <td>{{ reserva.numeroreservacm }}</td>
-        <td>{{ reserva.coduh }}</td>
-        <td>{{ reserva.nome_hospede }}</td>
-        <td>{{ reserva.data_checkin }}</td>
-        <td>{{ reserva.data_checkout }}</td>
-        <td>{{ reserva.qtd_hospedes }}</td>
-      </tr>
-    </ng-template>
-  </p-table>
+    <div class="lists">
+      <h3>Reservas</h3>
+      <p-table [value]="reservas">
+        <ng-template pTemplate="header">
+          <tr>
+            <th>Id Reserva CM</th>
+            <th>Número Reserva CM</th>
+            <th>Código UH</th>
+            <th>Nome Hóspede</th>
+            <th>Check-in</th>
+            <th>Check-out</th>
+            <th>Qtd Hóspedes</th>
+          </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-reserva>
+          <tr>
+            <td>{{ reserva.idreservacm }}</td>
+            <td>{{ reserva.numeroreservacm }}</td>
+            <td>{{ reserva.coduh }}</td>
+            <td>{{ reserva.nome_hospede }}</td>
+            <td>{{ reserva.data_checkin }}</td>
+            <td>{{ reserva.data_checkout }}</td>
+            <td>{{ reserva.qtd_hospedes }}</td>
+          </tr>
+        </ng-template>
+      </p-table>
 
-  <h3>Eventos</h3>
-  <p-table [value]="eventos">
-    <ng-template pTemplate="header">
-      <tr>
-        <th>Nome</th>
-        <th>Restaurante</th>
-        <th>Data</th>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="body" let-evento>
-      <tr>
-        <td>{{ evento.nome }}</td>
-        <td>{{ evento.restaurante }}</td>
-        <td>{{ evento.data }}</td>
-      </tr>
-    </ng-template>
-  </p-table>
-</div>
+      <h3>Eventos</h3>
+      <p-table [value]="eventos">
+        <ng-template pTemplate="header">
+          <tr>
+            <th>Nome</th>
+            <th>Restaurante</th>
+            <th>Data</th>
+          </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-evento>
+          <tr>
+            <td>{{ evento.nome }}</td>
+            <td>{{ evento.restaurante }}</td>
+            <td>{{ evento.data }}</td>
+          </tr>
+        </ng-template>
+      </p-table>
+    </div>
 
-<div class="form">
-  <h3>Vincular Reserva a Evento</h3>
-  <p-select [(ngModel)]="reservaSelecionada" [options]="reservas" optionLabel="numeroreservacm" placeholder="Selecione a reserva" ></p-select>
-  <p-select [(ngModel)]="eventoSelecionado" [options]="eventos" optionLabel="nome" placeholder="Selecione o evento" ></p-select>
-  <button pButton type="button" label="Vincular" (click)="vincular()" [disabled]="!reservaSelecionada || !eventoSelecionado"></button>
+    <div class="form">
+      <h3>Vincular Reserva a Evento</h3>
+      <p-select [(ngModel)]="reservaSelecionada" [options]="reservas" optionLabel="numeroreservacm" placeholder="Selecione a reserva" ></p-select>
+      <p-select [(ngModel)]="eventoSelecionado" [options]="eventos" optionLabel="nome" placeholder="Selecione o evento" ></p-select>
+      <button pButton type="button" label="Vincular" (click)="vincular()" [disabled]="!reservaSelecionada || !eventoSelecionado"></button>
+    </div>
+  </div>
+
+  <div class="right-column">
+    <p-datepicker [(ngModel)]="dataReserva" (ngModelChange)="consultarDisponibilidade()" placeholder="Data"></p-datepicker>
+    <p-select [(ngModel)]="eventoSelecionado" [options]="eventos" optionLabel="nome" placeholder="Evento" (ngModelChange)="consultarDisponibilidade()"></p-select>
+    <p-chart *ngIf="chartData" type="pie" [data]="chartData"></p-chart>
+    <div class="save-form">
+      <input type="text" [(ngModel)]="informacoes" placeholder="Informações" />
+      <input type="number" [(ngModel)]="quantidade" placeholder="Quantidade de pessoas" />
+      <button pButton type="button" label="Salvar" (click)="salvar()"></button>
+    </div>
+  </div>
 </div>

--- a/frontend/src/app/components/reserva-evento/reserva-evento.scss
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.scss
@@ -9,3 +9,25 @@
 .lists {
   margin-bottom: 2rem;
 }
+
+.layout {
+  display: flex;
+  gap: 2rem;
+}
+
+.left-column,
+.right-column {
+  flex: 1;
+}
+
+.right-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.save-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/frontend/src/app/services/reserva-evento.ts
+++ b/frontend/src/app/services/reserva-evento.ts
@@ -53,10 +53,33 @@ export class ReservaEventoService {
     );
   }
 
+  /** Consulta a disponibilidade de um evento em uma data específica */
+  getDisponibilidadeEvento(eventoId: number, data: string): Observable<{ capacidade: number; ocupacao: number }> {
+    return this.http
+      .get<any>(`${this.API_URL}/eventos/${eventoId}/disponibilidade`, { params: { data } })
+      .pipe(
+        map(res => res.data as { capacidade: number; ocupacao: number }),
+        catchError(error => {
+          console.error('❌ Erro ao consultar disponibilidade do evento:', error);
+          return throwError(() => error);
+        })
+      );
+  }
+
   vincular(reservaId: number, eventoId: number): Observable<any> {
     return this.http.post(`${this.API_URL}/eventos/${eventoId}/reservas`, { reservaId }).pipe(
       catchError(error => {
         console.error('❌ Erro ao vincular reserva ao evento:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  /** Salva uma nova reserva para o evento */
+  salvarReservaEvento(eventoId: number, payload: { informacoes: string; quantidade: number }): Observable<any> {
+    return this.http.post(`${this.API_URL}/eventos/${eventoId}/reservas`, payload).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao salvar reserva do evento:', error);
         return throwError(() => error);
       })
     );


### PR DESCRIPTION
## Summary
- show date and event selection with availability chart and save form
- fetch event availability and post reservation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689563e1d5c4832eb128f8db9faa330c