### PR TITLE
feat: add reserva evento screen

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -49,5 +49,7 @@ CREATE TABLE IF NOT EXISTS reservas (
 CREATE TABLE IF NOT EXISTS eventos_reservas (
   evento_id INTEGER NOT NULL REFERENCES eventos(id) ON DELETE CASCADE,
   reserva_id INTEGER NOT NULL REFERENCES reservas(id) ON DELETE CASCADE,
+  informacoes TEXT,
+  quantidade INTEGER DEFAULT 0,
   PRIMARY KEY (evento_id, reserva_id)
 );

--- a/frontend/src/app/components/reserva-evento/reserva-evento.html
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.html
@@ -1,96 +1,61 @@
 <p-toast></p-toast>
 
-<div class="layout">
-  <div class="left-column">
-    <div class="filters">
-      <p-select [(ngModel)]="filtroRestaurante" [options]="eventos" optionLabel="restaurante" optionValue="restaurante" placeholder="Restaurante"></p-select>
-      <p-select [(ngModel)]="filtroEvento" [options]="eventos" optionLabel="nome" optionValue="id" placeholder="Evento"></p-select>
-      <p-datepicker [(ngModel)]="filtroData" dateFormat="yy-mm-dd" placeholder="Data"></p-datepicker>
-      <button pButton type="button" label="Filtrar" (click)="aplicarFiltros()"></button>
+<div class="reserva-evento-layout">
+  <div class="left">
+    <h3>Reserva</h3>
+    <p-autoComplete
+      [(ngModel)]="reservaSelecionada"
+      [suggestions]="reservas"
+      field="coduh"
+      (completeMethod)="buscarReserva($event)"
+      placeholder="Código UH"
+    ></p-autoComplete>
+
+    <p-card *ngIf="reservaSelecionada" class="reserva-info">
+      <div>ID: {{ reservaSelecionada.id }}</div>
+      <div>Hóspede: {{ reservaSelecionada.nome_hospede }}</div>
+      <div>Check-in: {{ reservaSelecionada.data_checkin }}</div>
+      <div>Check-out: {{ reservaSelecionada.data_checkout }}</div>
+      <div>Hóspedes: {{ reservaSelecionada.qtd_hospedes }}</div>
+    </p-card>
+  </div>
+
+  <div class="right">
+    <h3>Evento</h3>
+    <p-datepicker [(ngModel)]="dataEvento" (onSelect)="selecionarData()" placeholder="Data do evento"></p-datepicker>
+    <p-dropdown
+      [(ngModel)]="eventoSelecionado"
+      [options]="eventos"
+      optionLabel="nome"
+      optionValue="id"
+      placeholder="Evento do dia"
+      (onChange)="onEventoChange()"
+    ></p-dropdown>
+
+    <div *ngIf="disponibilidade" class="disponibilidade">
+      <p-chart type="doughnut" [data]="chartData"></p-chart>
+      <div class="info">
+        <p>Capacidade: {{ disponibilidade.capacidade_total }}</p>
+        <p>Reservas: {{ disponibilidade.ocupacao }}</p>
+        <p>Vagas: {{ disponibilidade.vagas_restantes }}</p>
+      </div>
     </div>
 
-<div *ngIf="chartData" class="disponibilidade">
-  <p-chart type="doughnut" [data]="chartData"></p-chart>
-  <div class="info">
-    <p>Capacidade: {{ disponibilidade?.capacidade_total }}</p>
-    <p>Ocupação: {{ disponibilidade?.ocupacao }}</p>
-    <p>Vagas: {{ disponibilidade?.vagas_restantes }}</p>
-  </div>
-</div>
-
-<div class="lists">
-  <h3>Reservas</h3>
-  <p-table [value]="reservas">
-    <ng-template pTemplate="header">
-      <tr>
-        <th>Id Reserva CM</th>
-        <th>Número Reserva CM</th>
-        <th>Código UH</th>
-        <th>Nome Hóspede</th>
-        <th>Check-in</th>
-        <th>Check-out</th>
-        <th>Qtd Hóspedes</th>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="body" let-reserva>
-      <tr>
-        <td>{{ reserva.idreservacm }}</td>
-        <td>{{ reserva.numeroreservacm }}</td>
-        <td>{{ reserva.coduh }}</td>
-        <td>{{ reserva.nome_hospede }}</td>
-        <td>{{ reserva.data_checkin }}</td>
-        <td>{{ reserva.data_checkout }}</td>
-        <td>{{ reserva.qtd_hospedes }}</td>
-      </tr>
-    </ng-template>
-  </p-table>
-<div class="reserva-evento-container">
-  <div class="col">
-    <h3>Reserva</h3>
-    <p-select
-      [(ngModel)]="reservaSelecionada"
-      [options]="reservas"
-      optionLabel="numeroreservacm"
-      placeholder="Buscar reserva"
-      [filter]="true"
-      (onFilter)="filtrarReserva($event)"
-      (onChange)="mostrarDetalhes()"
-    ></p-select>
-  </div>
-
-  <div class="col">
-    <h3>Eventos</h3>
-    <p-table [value]="eventos">
-      <ng-template pTemplate="header">
-        <tr>
-          <th>Nome</th>
-          <th>Restaurante</th>
-          <th>Data</th>
-        </tr>
-      </ng-template>
-      <ng-template pTemplate="body" let-evento>
-        <tr>
-          <td>{{ evento.nome }}</td>
-          <td>{{ evento.restaurante }}</td>
-          <td>{{ evento.data }}</td>
-        </tr>
-      </ng-template>
-    </p-table>
-
-    <div class="form">
-      <p-select
-        [(ngModel)]="eventoSelecionado"
-        [options]="eventos"
-        optionLabel="nome"
-        placeholder="Selecione o evento"
-      ></p-select>
+    <div class="save-form">
+      <textarea
+        pInputTextarea
+        [(ngModel)]="informacoes"
+        placeholder="Informações adicionais"
+      ></textarea>
+      <p-inputNumber [(ngModel)]="quantidade" [min]="1" placeholder="Quantidade de pessoas"></p-inputNumber>
       <button
         pButton
         type="button"
-        label="Vincular"
-        (click)="vincular()"
+        label="Salvar marcação"
+        (click)="salvarMarcacao()"
         [disabled]="!reservaSelecionada || !eventoSelecionado"
       ></button>
     </div>
   </div>
 </div>
+

--- a/frontend/src/app/components/reserva-evento/reserva-evento.scss
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.scss
@@ -1,35 +1,19 @@
-// Layout em duas colunas
-.reserva-evento-container {
-  display: flex;
-  gap: 1rem;
-}
-
-.col {
-  flex: 1;
-}
-
-// Formulário de vínculo
-.form {
-  display: flex;
-  gap: 1rem;
-  margin-top: 1rem;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.layout {
+.reserva-evento-layout {
   display: flex;
   gap: 2rem;
 }
 
-.left-column,
-.right-column {
+.left,
+.right {
   flex: 1;
-}
-
-.right-column {
   display: flex;
   flex-direction: column;
+  gap: 1rem;
+}
+
+.disponibilidade {
+  display: flex;
+  align-items: center;
   gap: 1rem;
 }
 
@@ -37,4 +21,10 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  max-width: 300px;
 }
+
+.reserva-info div {
+  margin-bottom: 0.25rem;
+}
+

--- a/frontend/src/app/components/reserva-evento/reserva-evento.ts
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.ts
@@ -1,172 +1,138 @@
-/**
- * Componente de vinculação de reservas a eventos
- * Lista eventos e reservas, permite filtrar e realizar a vinculação
- */
-
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
 // PrimeNG
-import { TableModule } from 'primeng/table';
-import { SelectModule } from 'primeng/select';
+import { AutoCompleteModule } from 'primeng/autocomplete';
+import { DropdownModule } from 'primeng/dropdown';
+import { DatePickerModule } from 'primeng/datepicker';
+import { InputTextareaModule } from 'primeng/inputtextarea';
+import { InputNumberModule } from 'primeng/inputnumber';
 import { ButtonModule } from 'primeng/button';
 import { ToastModule } from 'primeng/toast';
 import { ChartModule } from 'primeng/chart';
+import { CardModule } from 'primeng/card';
 import { MessageService } from 'primeng/api';
 
 import { ReservaEventoService, Reserva, Evento, Disponibilidade } from '../../services/reserva-evento';
-import { extractErrorMessage } from '../../utils';
 
 @Component({
   selector: 'app-reserva-evento',
   standalone: true,
-  imports: [CommonModule, FormsModule, TableModule, SelectModule, DatePickerModule, ButtonModule, ToastModule, ChartModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    AutoCompleteModule,
+    DropdownModule,
+    DatePickerModule,
+    InputTextareaModule,
+    InputNumberModule,
+    ButtonModule,
+    ToastModule,
+    ChartModule,
+    CardModule,
+  ],
   providers: [MessageService],
   templateUrl: './reserva-evento.html',
-  styleUrls: ['./reserva-evento.scss']
+  styleUrls: ['./reserva-evento.scss'],
 })
-export class ReservaEventoComponent implements OnInit {
+export class ReservaEventoComponent {
   reservas: Reserva[] = [];
+  reservaSelecionada?: Reserva;
+
+  dataEvento?: Date | null;
   eventos: Evento[] = [];
+  eventoSelecionado?: Evento;
 
-  // filtros
-  filtroRestaurante?: number;
-  filtroEvento?: number;
-  filtroData?: Date | null;
-
-  // disponibilidade
   disponibilidade?: Disponibilidade;
   chartData?: any;
 
-  // seleção para vinculação
-  reservaSelecionada?: Reserva;
-  eventoSelecionado?: Evento;
-
-  // formulário direita
-  dataReserva?: Date | null;
   informacoes = '';
   quantidade?: number;
-  chartData: any;
 
-  constructor(private reservaEventoService: ReservaEventoService, private messageService: MessageService) {}
+  constructor(private service: ReservaEventoService, private message: MessageService) {}
 
-  ngOnInit(): void {
-    this.carregarEventos();
-  }
-
-  carregarEventos(): void {
-    this.reservaEventoService.getEventos().subscribe({
-      next: data => (this.eventos = data)
-    });
-
-    this.carregarDisponibilidade();
-  }
-
-  filtrarReserva(event: any): void {
-    const coduh = event.filter;
-    if (!coduh) {
+  buscarReserva(event: any): void {
+    const codigo = event.query;
+    if (!codigo) {
       this.reservas = [];
       return;
     }
     const hoje = new Date().toISOString().split('T')[0];
-    this.reservaEventoService
-      .buscarReserva(coduh, hoje, hoje)
-      .subscribe({ next: res => (this.reservas = res ? [res] : []) });
-  }
-
-  mostrarDetalhes(): void {
-    if (this.reservaSelecionada) {
-      const r = this.reservaSelecionada;
-      const detail = `Hóspede: ${r.nome_hospede} - Check-in: ${r.data_checkin} - Check-out: ${r.data_checkout}`;
-      this.messageService.add({ severity: 'info', summary: 'Reserva selecionada', detail });
-    }
-  }
-
-  carregarDisponibilidade(): void {
-    if (this.filtroEvento && this.filtroData) {
-      const data = this.filtroData.toISOString().split('T')[0];
-      this.reservaEventoService.getDisponibilidade(this.filtroEvento, data).subscribe({
-        next: res => {
-          this.disponibilidade = res;
-          this.chartData = {
-            labels: ['Ocupado', 'Disponível'],
-            datasets: [
-              {
-                data: [res.ocupacao, res.vagas_restantes],
-                backgroundColor: ['#EF4444', '#10B981']
-              }
-            ]
-          };
-        },
-        error: () => {
-          this.disponibilidade = undefined;
-          this.chartData = undefined;
-        }
-      });
-    } else {
-      this.disponibilidade = undefined;
-      this.chartData = undefined;
-    }
-  }
-
-  vincular(): void {
-    if (!this.reservaSelecionada || !this.eventoSelecionado) return;
-    this.reservaEventoService
-      .vincular(this.reservaSelecionada.id!, this.eventoSelecionado.id!)
-      .subscribe({
-        next: () => {
-          this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Reserva vinculada ao evento' });
-          this.carregarEventos();
-        },
-        error: err => {
-          let detail = 'Falha ao vincular reserva';
-          const msg = extractErrorMessage(err);
-          if (msg.toLowerCase().includes('capacidade')) {
-            detail = 'Capacidade do evento excedida';
-          } else if (msg.toLowerCase().includes('restaurante')) {
-            detail = 'Não é permitido múltiplos restaurantes no mesmo dia';
-          } else if (msg.toLowerCase().includes('duração')) {
-            detail = 'Limite de eventos por duração excedido';
-          }
-          this.messageService.add({ severity: 'error', summary: 'Erro', detail });
-        }
-      });
-  }
-
-  consultarDisponibilidade(): void {
-    if (!this.eventoSelecionado?.id || !this.dataReserva) return;
-    const data = this.dataReserva.toISOString().split('T')[0];
-    this.reservaEventoService.getDisponibilidadeEvento(this.eventoSelecionado.id, data).subscribe({
-      next: info => {
-        const vagas = info.capacidade - info.ocupacao;
-        this.chartData = {
-          labels: ['Vagas', 'Ocupado'],
-          datasets: [
-            {
-              data: [vagas, info.ocupacao],
-              backgroundColor: ['#4CAF50', '#FF5252']
-            }
-          ]
-        };
-      }
+    this.service.buscarReservaValida(codigo, hoje).subscribe({
+      next: r => (this.reservas = r ? [r] : []),
+      error: () => (this.reservas = []),
     });
   }
 
-  salvar(): void {
-    if (!this.eventoSelecionado?.id) return;
-    const payload = {
-      informacoes: this.informacoes,
-      quantidade: this.quantidade ?? 0
-    };
-    this.reservaEventoService.salvarReservaEvento(this.eventoSelecionado.id, payload).subscribe({
-      next: () => {
-        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Reserva salva' });
-        this.informacoes = '';
-        this.quantidade = undefined;
+  selecionarData(): void {
+    if (!this.dataEvento) {
+      this.eventos = [];
+      this.eventoSelecionado = undefined;
+      return;
+    }
+    const data = this.dataEvento.toISOString().split('T')[0];
+    this.service.getEventosPorData(data).subscribe({
+      next: evs => {
+        this.eventos = evs;
+        this.eventoSelecionado = undefined;
+        this.disponibilidade = undefined;
         this.chartData = undefined;
       },
-      error: () => this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao salvar reserva' })
+    });
+  }
+
+  onEventoChange(): void {
+    if (!this.eventoSelecionado?.id) {
+      this.disponibilidade = undefined;
+      this.chartData = undefined;
+      return;
+    }
+    this.service.getDisponibilidade(this.eventoSelecionado.id).subscribe({
+      next: info => {
+        this.disponibilidade = info;
+        this.chartData = {
+          labels: ['Reservas', 'Vagas'],
+          datasets: [
+            {
+              data: [info.ocupacao, info.vagas_restantes],
+              backgroundColor: ['#EF4444', '#10B981'],
+            },
+          ],
+        };
+      },
+      error: () => {
+        this.disponibilidade = undefined;
+        this.chartData = undefined;
+      },
+    });
+  }
+
+  salvarMarcacao(): void {
+    if (!this.reservaSelecionada || !this.eventoSelecionado || !this.quantidade) {
+      this.message.add({ severity: 'error', summary: 'Erro', detail: 'Preencha todos os campos' });
+      return;
+    }
+    if (this.disponibilidade && this.quantidade > this.disponibilidade.vagas_restantes) {
+      this.message.add({ severity: 'error', summary: 'Erro', detail: 'Quantidade excede vagas disponíveis' });
+      return;
+    }
+    const payload = {
+      reservaId: this.reservaSelecionada.id!,
+      informacoes: this.informacoes,
+      quantidade: this.quantidade,
+    };
+    this.service.marcar(this.eventoSelecionado.id!, payload).subscribe({
+      next: () => {
+        this.message.add({ severity: 'success', summary: 'Sucesso', detail: 'Marcação salva' });
+        this.informacoes = '';
+        this.quantidade = undefined;
+        this.onEventoChange();
+      },
+      error: err => {
+        const detail = err.error?.error || 'Falha ao salvar marcação';
+        this.message.add({ severity: 'error', summary: 'Erro', detail });
+      },
     });
   }
 }


### PR DESCRIPTION
## Summary
- implement reservation search and event booking backend endpoints
- create ReservaEventoComponent with autocomplete, availability chart and booking form
- update services and database schema for event markings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix frontend test` *(fails: Missing script: "test")*
- `npm --prefix backend test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68956a6dea80832e80f51b29919a75af