### PR TITLE
feat: melhorias no ReservaEventoComponent com layout aprimorado e regras de negócio

### DIFF
--- a/frontend/src/app/components/reserva-evento/reserva-evento.html
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.html
@@ -8,6 +8,7 @@
       [suggestions]="reservas"
       field="coduh"
       (completeMethod)="buscarReserva($event)"
+      (onSelect)="onReservaSelect()"
       placeholder="Código UH"
     ></p-autoComplete>
 
@@ -22,37 +23,90 @@
 
   <div class="right">
     <h3>Evento</h3>
-    <p-select
-      [(ngModel)]="eventoSelecionado"
-      [options]="eventos"
-      optionLabel="nome"
-      optionValue="id"
-      placeholder="Evento do dia"
-      (onChange)="onEventoChange()"
-    ></p-select>
+    
+    <div class="evento-selection">
+      <label for="dataEvento">Data do Evento:</label>
+      <p-datepicker 
+        id="dataEvento"
+        [(ngModel)]="dataEvento" 
+        (onSelect)="selecionarData()"
+        placeholder="Selecione a data"
+        [minDate]="hoje"
+      ></p-datepicker>
+    </div>
+
+    <div class="evento-selection" *ngIf="dataEvento">
+      <label for="evento">Evento do Dia:</label>
+      <p-select
+        id="evento"
+        [(ngModel)]="eventoSelecionado"
+        [options]="eventos"
+        optionLabel="nome"
+        placeholder="Selecione o evento"
+        (onChange)="onEventoChange()"
+      ></p-select>
+    </div>
 
     <div *ngIf="disponibilidade" class="disponibilidade">
-      <p-chart type="doughnut" [data]="chartData"></p-chart>
+      <div class="chart-container">
+        <p-chart type="doughnut" [data]="chartData" width="200" height="200"></p-chart>
+      </div>
       <div class="info">
-        <p>Capacidade: {{ disponibilidade.capacidade_total }}</p>
-        <p>Reservas: {{ disponibilidade.ocupacao }}</p>
-        <p>Vagas: {{ disponibilidade.vagas_restantes }}</p>
+        <h4>Disponibilidade</h4>
+        <p><strong>Capacidade Total:</strong> {{ disponibilidade.capacidade_total }}</p>
+        <p><strong>Já Reservado:</strong> {{ disponibilidade.ocupacao }}</p>
+        <p><strong>Vagas Restantes:</strong> 
+          <span [class.text-success]="disponibilidade.vagas_restantes > 0" 
+                [class.text-danger]="disponibilidade.vagas_restantes === 0">
+            {{ disponibilidade.vagas_restantes }}
+          </span>
+        </p>
       </div>
     </div>
 
-    <div class="save-form">
-      <textarea
-        pInputTextarea
-        [(ngModel)]="informacoes"
-        placeholder="Informações adicionais"
-      ></textarea>
-      <p-inputNumber [(ngModel)]="quantidade" [min]="1" placeholder="Quantidade de pessoas"></p-inputNumber>
+    <div *ngIf="marcacoesExistentes.length > 0" class="marcacoes-existentes">
+      <p-message severity="info" text="Marcações desta reserva:"></p-message>
+      <div class="marcacao-item" *ngFor="let marcacao of marcacoesExistentes">
+        <small>{{ marcacao.data_evento | date:'dd/MM/yyyy' }} - {{ marcacao.evento_nome }} ({{ marcacao.quantidade }} pessoas)</small>
+      </div>
+    </div>
+
+    <div class="save-form" *ngIf="eventoSelecionado && disponibilidade">
+      <h4>Formulário de Marcação</h4>
+      
+      <div class="form-field">
+        <label for="informacoes">Informações Adicionais:</label>
+        <textarea
+          id="informacoes"
+          pInputTextarea
+          [(ngModel)]="informacoes"
+          placeholder="Digite informações adicionais sobre a marcação"
+          rows="3"
+        ></textarea>
+      </div>
+      
+      <div class="form-field">
+        <label for="quantidade">Quantidade de Pessoas:</label>
+        <p-inputNumber 
+          id="quantidade"
+          [(ngModel)]="quantidade" 
+          [min]="1" 
+          [max]="disponibilidade.vagas_restantes || 999"
+          placeholder="Número de pessoas"
+        ></p-inputNumber>
+        <small *ngIf="disponibilidade" class="quantity-hint">
+          Máximo disponível: {{ disponibilidade.vagas_restantes }} pessoas
+        </small>
+      </div>
+      
       <button
         pButton
         type="button"
-        label="Salvar marcação"
+        label="Salvar Marcação"
+        icon="pi pi-check"
         (click)="salvarMarcacao()"
-        [disabled]="!reservaSelecionada || !eventoSelecionado"
+        [disabled]="!reservaSelecionada || !eventoSelecionado || !quantidade || !dataEvento"
+        class="save-button"
       ></button>
     </div>
   </div>

--- a/frontend/src/app/components/reserva-evento/reserva-evento.scss
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.scss
@@ -13,18 +13,130 @@
 
 .disponibilidade {
   display: flex;
-  align-items: center;
-  gap: 1rem;
+  align-items: flex-start;
+  gap: 1.5rem;
+  margin: 1rem 0;
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #f9f9f9;
+}
+
+.chart-container {
+  flex-shrink: 0;
+}
+
+.disponibilidade .info {
+  flex: 1;
+}
+
+.disponibilidade .info h4 {
+  margin: 0 0 0.5rem 0;
+  color: #333;
+}
+
+.disponibilidade .info p {
+  margin: 0.25rem 0;
+}
+
+.text-success {
+  color: #10B981;
+  font-weight: bold;
+}
+
+.text-danger {
+  color: #EF4444;
+  font-weight: bold;
 }
 
 .save-form {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  max-width: 300px;
+  gap: 1rem;
+  max-width: 400px;
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.save-form h4 {
+  margin: 0 0 1rem 0;
+  color: #333;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.form-field label {
+  font-weight: 500;
+  color: #555;
+  font-size: 0.9rem;
+}
+
+.form-field textarea {
+  resize: vertical;
+}
+
+.quantity-hint {
+  color: #666;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}
+
+.save-button {
+  margin-top: 0.5rem;
+  padding: 0.75rem 1.5rem;
 }
 
 .reserva-info div {
   margin-bottom: 0.25rem;
+}
+
+.evento-selection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.evento-selection label {
+  font-weight: 500;
+  color: #555;
+  font-size: 0.9rem;
+}
+
+.marcacoes-existentes {
+  margin: 1rem 0;
+  padding: 1rem;
+  border-radius: 8px;
+  background: #f0f8ff;
+}
+
+.marcacao-item {
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  background: #ffffff;
+  border-radius: 4px;
+  border-left: 3px solid #007bff;
+}
+
+@media (max-width: 768px) {
+  .reserva-evento-layout {
+    flex-direction: column;
+  }
+  
+  .disponibilidade {
+    flex-direction: column;
+    text-align: center;
+  }
+  
+  .save-form {
+    max-width: 100%;
+  }
 }
 

--- a/frontend/src/app/components/reserva-evento/reserva-evento.ts
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.ts
@@ -11,6 +11,8 @@ import { ButtonModule } from 'primeng/button';
 import { ToastModule } from 'primeng/toast';
 import { ChartModule } from 'primeng/chart';
 import { CardModule } from 'primeng/card';
+import { DatePickerModule } from 'primeng/datepicker';
+import { MessageModule } from 'primeng/message';
 import { MessageService } from 'primeng/api';
 
 import { ReservaEventoService, Reserva, Evento, Disponibilidade } from '../../services/reserva-evento.service';
@@ -29,6 +31,8 @@ import { ReservaEventoService, Reserva, Evento, Disponibilidade } from '../../se
     ToastModule,
     ChartModule,
     CardModule,
+    DatePickerModule,
+    MessageModule,
   ],
   providers: [MessageService],
   templateUrl: './reserva-evento.html',
@@ -41,9 +45,11 @@ export class ReservaEventoComponent {
   dataEvento?: Date | null;
   eventos: Evento[] = [];
   eventoSelecionado?: Evento;
+  hoje = new Date();
 
   disponibilidade?: Disponibilidade;
   chartData?: any;
+  marcacoesExistentes: any[] = [];
 
   informacoes = '';
   quantidade?: number;
@@ -58,9 +64,18 @@ export class ReservaEventoComponent {
     }
     const hoje = new Date().toISOString().split('T')[0];
     this.service.buscarReservaValida(codigo, hoje).subscribe({
-      next: r => (this.reservas = r ? [r] : []),
+      next: r => {
+        this.reservas = r ? [r] : [];
+        if (r) {
+          this.carregarMarcacoesExistentes();
+        }
+      },
       error: () => (this.reservas = []),
     });
+  }
+
+  onReservaSelect(): void {
+    this.carregarMarcacoesExistentes();
   }
 
   selecionarData(): void {
@@ -107,30 +122,100 @@ export class ReservaEventoComponent {
   }
 
   salvarMarcacao(): void {
-    if (!this.reservaSelecionada || !this.eventoSelecionado || !this.quantidade) {
+    if (!this.reservaSelecionada || !this.eventoSelecionado || !this.quantidade || !this.dataEvento) {
       this.message.add({ severity: 'error', summary: 'Erro', detail: 'Preencha todos os campos' });
       return;
     }
+    
+    // Validar regras de negócio
+    const validacao = this.validarRegrasNegocio();
+    if (!validacao.valido) {
+      this.message.add({ severity: 'error', summary: 'Erro', detail: validacao.mensagem });
+      return;
+    }
+    
     if (this.disponibilidade && this.quantidade > this.disponibilidade.vagas_restantes) {
       this.message.add({ severity: 'error', summary: 'Erro', detail: 'Quantidade excede vagas disponíveis' });
       return;
     }
+    
     const payload = {
       reservaId: this.reservaSelecionada.id!,
       informacoes: this.informacoes,
       quantidade: this.quantidade,
     };
+    
     this.service.marcar(this.eventoSelecionado.id!, payload).subscribe({
       next: () => {
         this.message.add({ severity: 'success', summary: 'Sucesso', detail: 'Marcação salva' });
         this.informacoes = '';
         this.quantidade = undefined;
         this.onEventoChange();
+        this.carregarMarcacoesExistentes();
       },
       error: err => {
         const detail = err.error?.error || 'Falha ao salvar marcação';
         this.message.add({ severity: 'error', summary: 'Erro', detail });
       },
+    });
+  }
+
+  private validarRegrasNegocio(): { valido: boolean; mensagem: string } {
+    if (!this.reservaSelecionada || !this.dataEvento) {
+      return { valido: false, mensagem: 'Dados insuficientes para validação' };
+    }
+
+    // Calcular dias da reserva
+    const checkin = new Date(this.reservaSelecionada.data_checkin!);
+    const checkout = new Date(this.reservaSelecionada.data_checkout!);
+    const diasReserva = Math.ceil((checkout.getTime() - checkin.getTime()) / (1000 * 60 * 60 * 24));
+
+    // Determinar limite de marcações baseado no período
+    let limiteMarcacoes = 1;
+    if (diasReserva >= 7) {
+      limiteMarcacoes = 3;
+    } else if (diasReserva >= 3) {
+      limiteMarcacoes = 2;
+    }
+
+    // Contar marcações existentes para esta reserva
+    const totalMarcacoes = this.marcacoesExistentes.length;
+    if (totalMarcacoes >= limiteMarcacoes) {
+      return { 
+        valido: false, 
+        mensagem: `Limite de ${limiteMarcacoes} marcação(ões) atingido para esta reserva (${diasReserva} dias)` 
+      };
+    }
+
+    // Verificar se já existe marcação para o mesmo dia
+    const dataEventoStr = this.dataEvento.toISOString().split('T')[0];
+    const marcacaoMesmoDia = this.marcacoesExistentes.find(m => 
+      new Date(m.data_evento).toISOString().split('T')[0] === dataEventoStr
+    );
+    
+    if (marcacaoMesmoDia) {
+      return { 
+        valido: false, 
+        mensagem: 'Esta reserva já possui uma marcação para este dia' 
+      };
+    }
+
+    return { valido: true, mensagem: '' };
+  }
+
+  private carregarMarcacoesExistentes(): void {
+    if (!this.reservaSelecionada?.id) {
+      this.marcacoesExistentes = [];
+      return;
+    }
+    
+    this.service.getMarcacoesDaReserva(this.reservaSelecionada.id).subscribe({
+      next: marcacoes => {
+        this.marcacoesExistentes = marcacoes;
+      },
+      error: () => {
+        this.marcacoesExistentes = [];
+      }
     });
   }
 }

--- a/frontend/src/app/services/reserva-evento.service.ts
+++ b/frontend/src/app/services/reserva-evento.service.ts
@@ -83,6 +83,16 @@ export class ReservaEventoService {
       );
   }
 
+  /** Obtém todas as marcações de uma reserva */
+  getMarcacoesDaReserva(reservaId: number): Observable<any[]> {
+    return this.http.get<any[]>(`${this.API_URL}/reservas/${reservaId}/marcacoes`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao obter marcações da reserva:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
   /** Realiza a marcação do evento */
   marcar(eventoId: number, payload: { reservaId: number; informacoes: string; quantidade: number }): Observable<any> {
     return this.http.post(`${this.API_URL}/eventos/${eventoId}/marcar`, payload).pipe(


### PR DESCRIPTION
## Summary
• Implementa layout de duas colunas com seleção de reserva (esquerda) e evento + formulário (direita)
• Adiciona p-datepicker para seleção de data do evento 
• Implementa todas as regras de negócio solicitadas com validações robustas
• Melhora significativamente a UX com visualizações aprimoradas de disponibilidade

## Principais Melhorias

### 🎨 Layout e UX
- Layout de duas colunas responsivo conforme especificação
- p-datepicker com validação de data mínima (hoje)
- Formulário de marcação organizado com labels e validações visuais
- Gráfico doughnut melhorado para visualização da disponibilidade
- Exibição de marcações existentes da reserva

### 🧠 Regras de Negócio Implementadas
- **Limites por período da reserva:**
  - < 3 dias → máximo 1 marcação
  - 3 a 7 dias → até 2 marcações  
  - ≥ 7 dias → até 3 marcações
- **Validação:** mesma reserva não pode ter mais de um evento no mesmo dia
- **Validação:** quantidade não pode exceder vagas disponíveis
- **Mensagens de erro específicas** via p-toast para cada violação

### 🔧 Melhorias Técnicas
- Novo endpoint `getMarcacoesDaReserva` no serviço
- Validação completa antes do salvamento com método `validarRegrasNegocio()`
- Imports adicionados: DatePickerModule, MessageModule
- CSS responsivo com media queries
- Carregamento automático de marcações existentes ao selecionar reserva

### 📱 Responsividade
- Layout adapta para mobile (flex-direction: column)
- Formulário e gráficos ajustam para telas menores

## Test Plan
- [x] Build sem erros de compilação ✅
- [x] Imports e dependências corretas ✅
- [x] Layout responsivo testado ✅
- [x] Validações de regras de negócio implementadas ✅

## Arquivos Modificados
- `reserva-evento.html` - Layout e template aprimorado
- `reserva-evento.ts` - Lógica de negócio e validações  
- `reserva-evento.scss` - Estilos responsivos e visual melhorado
- `reserva-evento.service.ts` - Novo endpoint para marcações da reserva

🤖 Generated with [Claude Code](https://claude.ai/code)