### PR TITLE
fix: improve UH search display

### DIFF
--- a/frontend/src/app/components/reserva-evento/reserva-evento.html
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.html
@@ -6,7 +6,7 @@
     <p-autoComplete
       [(ngModel)]="reservaSelecionada"
       [suggestions]="reservas"
-      field="coduh"
+      field="descricao"
       (completeMethod)="buscarReserva($event)"
       (onSelect)="onReservaSelect()"
       placeholder="Código UH"

--- a/frontend/src/app/components/reserva-evento/reserva-evento.ts
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.ts
@@ -65,12 +65,23 @@ export class ReservaEventoComponent {
     const hoje = new Date().toISOString().split('T')[0];
     this.service.buscarReservaValida(codigo, hoje).subscribe({
       next: r => {
-        this.reservas = r ? [r] : [];
         if (r) {
+          this.reservas = [{ ...r, descricao: `${r.coduh} - ${r.nome_hospede}` }];
           this.carregarMarcacoesExistentes();
+        } else {
+          this.reservas = [];
+          this.reservaSelecionada = undefined;
+          this.message.add({
+            severity: 'warn',
+            summary: 'Aviso',
+            detail: 'Não existe nenhum apartamento check-in no período de hoje com a UH informada',
+          });
         }
       },
-      error: () => (this.reservas = []),
+      error: () => {
+        this.reservas = [];
+        this.reservaSelecionada = undefined;
+      },
     });
   }
 

--- a/frontend/src/app/services/reserva-evento.service.ts
+++ b/frontend/src/app/services/reserva-evento.service.ts
@@ -16,6 +16,7 @@ export interface Reserva {
   data_checkin?: string;
   data_checkout?: string;
   qtd_hospedes?: number;
+  descricao?: string;
 }
 
 export interface Evento {


### PR DESCRIPTION
## Summary
- add feedback when no apartment is found for the informed UH
- show apartment number and guest name in UH autocomplete

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68960db2a210832eb7d99b12c086840e