### PR TITLE
feat: add voucher printing for reservation events

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -41,6 +41,7 @@ export const routes: Routes = [
       { path: 'reservas/novo', loadComponent: () => import('./components/reservas/reserva-form').then(m => m.ReservaFormComponent) },
       { path: 'reservas/:id', loadComponent: () => import('./components/reservas/reserva-form').then(m => m.ReservaFormComponent) },
       { path: 'reserva-evento', loadComponent: () => import('./components/reserva-evento/reserva-evento').then(m => m.ReservaEventoComponent) },
+      { path: 'reserva-voucher/:reservaId/:eventoId', loadComponent: () => import('./components/reserva-voucher/reserva-voucher').then(m => m.ReservaVoucherComponent) },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: '**', redirectTo: 'dashboard' }
     ]

--- a/frontend/src/app/components/reserva-evento/reserva-evento.html
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.html
@@ -68,6 +68,7 @@
       <p-message severity="info" text="Marcações desta reserva:"></p-message>
       <div class="marcacao-item" *ngFor="let marcacao of marcacoesExistentes">
         <small>{{ marcacao.data_evento | date:'dd/MM/yyyy' }} - {{ marcacao.evento_nome }} ({{ marcacao.quantidade }} pessoas)</small>
+        <button pButton type="button" label="Imprimir Voucher" icon="pi pi-print" class="p-button-text" (click)="abrirVoucher(marcacao)"></button>
       </div>
     </div>
 

--- a/frontend/src/app/components/reserva-evento/reserva-evento.ts
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 
 // PrimeNG
 import { AutoCompleteModule } from 'primeng/autocomplete';
@@ -54,7 +55,7 @@ export class ReservaEventoComponent {
   informacoes = '';
   quantidade?: number;
 
-  constructor(private service: ReservaEventoService, private message: MessageService) {}
+  constructor(private service: ReservaEventoService, private message: MessageService, private router: Router) {}
 
   buscarReserva(event: any): void {
     const codigo = event.query;
@@ -217,6 +218,13 @@ export class ReservaEventoComponent {
         this.marcacoesExistentes = [];
       }
     });
+  }
+
+  abrirVoucher(marcacao: any): void {
+    const eventoId = marcacao.evento_id || marcacao.eventoId;
+    if (this.reservaSelecionada?.id && eventoId) {
+      this.router.navigate(['/reserva-voucher', this.reservaSelecionada.id, eventoId]);
+    }
   }
 }
 

--- a/frontend/src/app/components/reserva-voucher/reserva-voucher.html
+++ b/frontend/src/app/components/reserva-voucher/reserva-voucher.html
@@ -1,0 +1,26 @@
+<div class="voucher-container" *ngIf="voucher">
+  <h2>Voucher de Evento</h2>
+
+  <section class="reserva">
+    <h3>Reserva</h3>
+    <p><strong>Hóspede:</strong> {{ voucher.reserva.nome_hospede }}</p>
+    <p><strong>UH:</strong> {{ voucher.reserva.coduh }}</p>
+    <p><strong>Check-in:</strong> {{ voucher.reserva.data_checkin }}</p>
+    <p><strong>Check-out:</strong> {{ voucher.reserva.data_checkout }}</p>
+  </section>
+
+  <section class="evento">
+    <h3>Evento</h3>
+    <p><strong>Nome:</strong> {{ voucher.evento.nome }}</p>
+    <p><strong>Data:</strong> {{ voucher.evento.data | date: 'dd/MM/yyyy' }}</p>
+    <p><strong>Restaurante:</strong> {{ voucher.evento.restaurante }}</p>
+  </section>
+
+  <section class="status" *ngIf="voucher.status">
+    <h3>Status</h3>
+    <p><strong>Quantidade:</strong> {{ voucher.status.quantidade }}</p>
+    <p *ngIf="voucher.status.informacoes"><strong>Informações:</strong> {{ voucher.status.informacoes }}</p>
+  </section>
+
+  <button pButton type="button" label="Imprimir" icon="pi pi-print" (click)="imprimir()"></button>
+</div>

--- a/frontend/src/app/components/reserva-voucher/reserva-voucher.scss
+++ b/frontend/src/app/components/reserva-voucher/reserva-voucher.scss
@@ -1,0 +1,13 @@
+.voucher-container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+section {
+  margin-bottom: 1rem;
+}
+
+button {
+  margin-top: 1rem;
+}

--- a/frontend/src/app/components/reserva-voucher/reserva-voucher.ts
+++ b/frontend/src/app/components/reserva-voucher/reserva-voucher.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { ReservaEventoService, Voucher } from '../../services/reserva-evento.service';
+
+@Component({
+  selector: 'app-reserva-voucher',
+  standalone: true,
+  imports: [CommonModule, ButtonModule],
+  templateUrl: './reserva-voucher.html',
+  styleUrls: ['./reserva-voucher.scss']
+})
+export class ReservaVoucherComponent implements OnInit {
+  voucher?: Voucher;
+
+  constructor(private route: ActivatedRoute, private service: ReservaEventoService) {}
+
+  ngOnInit(): void {
+    const reservaId = Number(this.route.snapshot.paramMap.get('reservaId'));
+    const eventoId = Number(this.route.snapshot.paramMap.get('eventoId'));
+    if (reservaId && eventoId) {
+      this.service.getVoucher(reservaId, eventoId).subscribe(v => (this.voucher = v));
+    }
+  }
+
+  imprimir(): void {
+    window.print();
+  }
+}

--- a/frontend/src/app/services/reserva-evento.service.ts
+++ b/frontend/src/app/services/reserva-evento.service.ts
@@ -4,7 +4,7 @@
 
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, catchError, throwError, map } from 'rxjs';
+import { Observable, catchError, throwError, map, forkJoin } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 export interface Reserva {
@@ -29,6 +29,12 @@ export interface Disponibilidade {
   capacidade_total: number;
   ocupacao: number;
   vagas_restantes: number;
+}
+
+export interface Voucher {
+  reserva: Reserva;
+  evento: Evento;
+  status: any | null;
 }
 
 @Injectable({
@@ -88,6 +94,25 @@ export class ReservaEventoService {
     return this.http.get<any[]>(`${this.API_URL}/reservas/${reservaId}/marcacoes`).pipe(
       catchError(error => {
         console.error('❌ Erro ao obter marcações da reserva:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  /** Obtém dados completos de reserva, evento e marcação para impressão */
+  getVoucher(reservaId: number, eventoId: number): Observable<Voucher> {
+    return forkJoin({
+      reserva: this.http.get<Reserva>(`${this.API_URL}/reservas/${reservaId}`),
+      evento: this.http.get<Evento>(`${this.API_URL}/eventos/${eventoId}`),
+      marcacoes: this.getMarcacoes(eventoId, reservaId)
+    }).pipe(
+      map(result => ({
+        reserva: result.reserva,
+        evento: result.evento,
+        status: result.marcacoes.length > 0 ? result.marcacoes[0] : null
+      })),
+      catchError(error => {
+        console.error('❌ Erro ao obter voucher:', error);
         return throwError(() => error);
       })
     );


### PR DESCRIPTION
## Summary
- add `getVoucher` API call to `ReservaEventoService` for combined reservation and event details
- create `reserva-voucher` component with print-ready layout
- expose voucher printing via new route and buttons in reservation-event view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `(cd backend && npm test)` *(fails: Missing script: "test")*
- `(cd frontend && npm test)` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68962718fe98832eac9beb9eb62e277d