### PR TITLE
feat: add event reservation listing

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -41,6 +41,7 @@ export const routes: Routes = [
       { path: 'reservas/novo', loadComponent: () => import('./components/reservas/reserva-form').then(m => m.ReservaFormComponent) },
       { path: 'reservas/:id', loadComponent: () => import('./components/reservas/reserva-form').then(m => m.ReservaFormComponent) },
       { path: 'reserva-evento', loadComponent: () => import('./components/reserva-evento/reserva-evento').then(m => m.ReservaEventoComponent) },
+      { path: 'reserva-evento-list', loadComponent: () => import('./components/reserva-evento-list/reserva-evento-list').then(m => m.ReservaEventoListComponent) },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: '**', redirectTo: 'dashboard' }
     ]

--- a/frontend/src/app/components/reserva-evento-list/reserva-evento-list.html
+++ b/frontend/src/app/components/reserva-evento-list/reserva-evento-list.html
@@ -1,0 +1,36 @@
+<p-card>
+  <div class="font-semibold text-xl mb-4">Marcações de Eventos</div>
+  <p-toolbar>
+    <div class="p-toolbar-start"></div>
+    <div class="p-toolbar-end"></div>
+  </p-toolbar>
+  <p-table [value]="marcacoes" [loading]="isLoading">
+    <ng-template pTemplate="header">
+      <tr>
+        <th>Evento</th>
+        <th>Data</th>
+        <th>Restaurante</th>
+        <th>Reserva</th>
+        <th>Status</th>
+      </tr>
+    </ng-template>
+    <ng-template pTemplate="body" let-m>
+      <tr>
+        <td>{{ m.evento_nome }}</td>
+        <td>{{ m.evento_data | date:'dd/MM/yyyy' }}</td>
+        <td>{{ m.restaurante }}</td>
+        <td>{{ m.nome_hospede }}</td>
+        <td class="status-cell">
+          <p-tag [value]="m.status" [severity]="getStatusSeverity(m.status)"></p-tag>
+          <p-select
+            [options]="statusOptions"
+            [(ngModel)]="m.status"
+            (onChange)="alterarStatus(m)"
+            styleClass="status-select"
+          ></p-select>
+        </td>
+      </tr>
+    </ng-template>
+  </p-table>
+</p-card>
+<p-toast></p-toast>

--- a/frontend/src/app/components/reserva-evento-list/reserva-evento-list.scss
+++ b/frontend/src/app/components/reserva-evento-list/reserva-evento-list.scss
@@ -1,0 +1,5 @@
+.status-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/frontend/src/app/components/reserva-evento-list/reserva-evento-list.ts
+++ b/frontend/src/app/components/reserva-evento-list/reserva-evento-list.ts
@@ -1,0 +1,85 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+// PrimeNG
+import { TableModule } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { SelectModule } from 'primeng/select';
+import { ToastModule } from 'primeng/toast';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { ToolbarModule } from 'primeng/toolbar';
+import { MessageService } from 'primeng/api';
+
+import { ReservaEventoService, Marcacao } from '../../services/reserva-evento.service';
+
+@Component({
+  selector: 'app-reserva-evento-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    TableModule,
+    TagModule,
+    SelectModule,
+    ToastModule,
+    ButtonModule,
+    CardModule,
+    ToolbarModule
+  ],
+  providers: [MessageService],
+  templateUrl: './reserva-evento-list.html',
+  styleUrls: ['./reserva-evento-list.scss']
+})
+export class ReservaEventoListComponent implements OnInit {
+  marcacoes: Marcacao[] = [];
+  isLoading = false;
+
+  statusOptions = [
+    { label: 'Pendente', value: 'PENDENTE' },
+    { label: 'Confirmado', value: 'CONFIRMADO' },
+    { label: 'Cancelado', value: 'CANCELADO' }
+  ];
+
+  constructor(private service: ReservaEventoService, private message: MessageService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading = true;
+    this.service.getEventosReservas().subscribe({
+      next: res => {
+        this.marcacoes = res;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.isLoading = false;
+      }
+    });
+  }
+
+  alterarStatus(m: Marcacao): void {
+    this.service.updateMarcacaoStatus(m.id, m.status).subscribe({
+      next: () => {
+        this.message.add({ severity: 'success', summary: 'Sucesso', detail: 'Status atualizado' });
+      },
+      error: () => {
+        this.message.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao atualizar status' });
+      }
+    });
+  }
+
+  getStatusSeverity(status: string): string {
+    switch ((status || '').toLowerCase()) {
+      case 'confirmado':
+        return 'success';
+      case 'cancelado':
+        return 'danger';
+      default:
+        return 'info';
+    }
+  }
+}

--- a/frontend/src/app/services/reserva-evento.service.ts
+++ b/frontend/src/app/services/reserva-evento.service.ts
@@ -31,6 +31,17 @@ export interface Disponibilidade {
   vagas_restantes: number;
 }
 
+export interface Marcacao {
+  id: number;
+  evento_id: number;
+  evento_nome: string;
+  evento_data: string;
+  restaurante: string;
+  reserva_id: number;
+  numero_reserva: string;
+  nome_hospede: string;
+  status: string;
+}
 @Injectable({
   providedIn: 'root'
 })
@@ -98,6 +109,26 @@ export class ReservaEventoService {
     return this.http.post(`${this.API_URL}/eventos/${eventoId}/marcar`, payload).pipe(
       catchError(error => {
         console.error('❌ Erro ao salvar marcação:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  /** Lista todas as marcações com detalhes de evento e reserva */
+  getEventosReservas(): Observable<Marcacao[]> {
+    return this.http.get<Marcacao[]>(`${this.API_URL}/eventos-reservas`).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao listar marcações:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  /** Atualiza o status da marcação */
+  updateMarcacaoStatus(id: number, status: string): Observable<any> {
+    return this.http.put(`${this.API_URL}/eventos-reservas/${id}`, { status }).pipe(
+      catchError(error => {
+        console.error('❌ Erro ao atualizar marcação:', error);
         return throwError(() => error);
       })
     );


### PR DESCRIPTION
## Summary
- list event reservations with editable status
- expose API service helpers for listing and status update
- register page route for reservation-event list

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68962719a8d4832e9b5df728b8e7f48f