### PR TITLE
Add event reservation backend and model

### DIFF
--- a/backend/models/eventoReservaModel.js
+++ b/backend/models/eventoReservaModel.js
@@ -1,0 +1,72 @@
+const { getDatabase } = require('../config/database');
+
+async function findAll() {
+  const db = getDatabase();
+  const { rows } = await db.query(
+    'SELECT evento_id, reserva_id, informacoes, quantidade, status FROM eventos_reservas'
+  );
+  return rows;
+}
+
+async function findById(eventoId, reservaId) {
+  const db = getDatabase();
+  const { rows: [row] } = await db.query(
+    'SELECT evento_id, reserva_id, informacoes, quantidade, status FROM eventos_reservas WHERE evento_id = ? AND reserva_id = ?',
+    [eventoId, reservaId]
+  );
+  return row;
+}
+
+async function create({ eventoId, reservaId, informacoes, quantidade, status }) {
+  const db = getDatabase();
+  await db.query(
+    'INSERT INTO eventos_reservas (evento_id, reserva_id, informacoes, quantidade, status) VALUES (?, ?, ?, ?, ?)',
+    [eventoId, reservaId, informacoes || null, quantidade, status || 'Ativa']
+  );
+  return { evento_id: eventoId, reserva_id: reservaId, informacoes: informacoes || null, quantidade, status: status || 'Ativa' };
+}
+
+async function update(eventoId, reservaId, { informacoes, quantidade, status }) {
+  const db = getDatabase();
+  const fields = [];
+  const values = [];
+
+  if (informacoes !== undefined) {
+    fields.push('informacoes = ?');
+    values.push(informacoes);
+  }
+  if (quantidade !== undefined) {
+    fields.push('quantidade = ?');
+    values.push(quantidade);
+  }
+  if (status !== undefined) {
+    fields.push('status = ?');
+    values.push(status);
+  }
+
+  if (fields.length === 0) {
+    return 0;
+  }
+
+  values.push(eventoId, reservaId);
+  const sql = `UPDATE eventos_reservas SET ${fields.join(', ')} WHERE evento_id = ? AND reserva_id = ?`;
+  const result = await db.query(sql, values);
+  return result.rowCount;
+}
+
+async function remove(eventoId, reservaId) {
+  const db = getDatabase();
+  const result = await db.query(
+    'DELETE FROM eventos_reservas WHERE evento_id = ? AND reserva_id = ?',
+    [eventoId, reservaId]
+  );
+  return result.rowCount;
+}
+
+module.exports = {
+  findAll,
+  findById,
+  create,
+  update,
+  remove
+};

--- a/backend/routes/eventos_reservas.js
+++ b/backend/routes/eventos_reservas.js
@@ -1,0 +1,97 @@
+const express = require('express');
+const { ApiError } = require('../middleware/errorHandler');
+const model = require('../models/eventoReservaModel');
+
+const router = express.Router();
+
+function isValidInt(value) {
+  return Number.isInteger(Number(value));
+}
+
+router.get('/', async (req, res, next) => {
+  try {
+    const rows = await model.findAll();
+    res.json(rows);
+  } catch (err) {
+    console.error('❌ Erro ao listar marcações:', err.message);
+    next(new ApiError(500, 'Erro ao listar marcações', 'LIST_MARCACOES_ERROR', err.message));
+  }
+});
+
+router.get('/:eventoId/:reservaId', async (req, res, next) => {
+  const { eventoId, reservaId } = req.params;
+  if (!isValidInt(eventoId) || !isValidInt(reservaId)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  try {
+    const row = await model.findById(eventoId, reservaId);
+    if (!row) {
+      return next(new ApiError(404, 'Marcação não encontrada', 'MARCACAO_NOT_FOUND'));
+    }
+    res.json(row);
+  } catch (err) {
+    console.error('❌ Erro ao obter marcação:', err.message);
+    next(new ApiError(500, 'Erro ao obter marcação', 'GET_MARCACAO_ERROR', err.message));
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  const { eventoId, reservaId, informacoes, quantidade, status } = req.body;
+  if (!isValidInt(eventoId) || !isValidInt(reservaId) || !isValidInt(quantidade)) {
+    return next(new ApiError(400, 'Dados inválidos', 'INVALID_FIELDS'));
+  }
+  try {
+    const created = await model.create({ eventoId, reservaId, informacoes, quantidade, status });
+    res.status(201).json(created);
+  } catch (err) {
+    console.error('❌ Erro ao criar marcação:', err.message);
+    next(new ApiError(500, 'Erro ao criar marcação', 'CREATE_MARCACAO_ERROR', err.message));
+  }
+});
+
+router.put('/:eventoId/:reservaId', async (req, res, next) => {
+  const { eventoId, reservaId } = req.params;
+  if (!isValidInt(eventoId) || !isValidInt(reservaId)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  const { informacoes, quantidade, status } = req.body;
+  if (
+    informacoes === undefined &&
+    quantidade === undefined &&
+    status === undefined
+  ) {
+    return next(new ApiError(400, 'Nenhum dado para atualizar', 'NO_FIELDS_TO_UPDATE'));
+  }
+  if (quantidade !== undefined && !isValidInt(quantidade)) {
+    return next(new ApiError(400, 'quantidade inválida', 'INVALID_QUANTIDADE'));
+  }
+  try {
+    const updated = await model.update(eventoId, reservaId, { informacoes, quantidade, status });
+    if (updated === 0) {
+      return next(new ApiError(404, 'Marcação não encontrada', 'MARCACAO_NOT_FOUND'));
+    }
+    res.json({ message: 'Marcação atualizada com sucesso' });
+  } catch (err) {
+    console.error('❌ Erro ao atualizar marcação:', err.message);
+    next(new ApiError(500, 'Erro ao atualizar marcação', 'UPDATE_MARCACAO_ERROR', err.message));
+  }
+});
+
+router.delete('/:eventoId/:reservaId', async (req, res, next) => {
+  const { eventoId, reservaId } = req.params;
+  if (!isValidInt(eventoId) || !isValidInt(reservaId)) {
+    return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
+  }
+  try {
+    const removed = await model.remove(eventoId, reservaId);
+    if (removed === 0) {
+      return next(new ApiError(404, 'Marcação não encontrada', 'MARCACAO_NOT_FOUND'));
+    }
+    res.json({ message: 'Marcação removida com sucesso' });
+  } catch (err) {
+    console.error('❌ Erro ao remover marcação:', err.message);
+    next(new ApiError(500, 'Erro ao remover marcação', 'DELETE_MARCACAO_ERROR', err.message));
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,6 +20,7 @@ const usersRoutes = require('./routes/users');
 const restaurantesRoutes = require('./routes/restaurantes');
 const eventosRoutes = require('./routes/eventos');
 const reservasRoutes = require('./routes/reservas');
+const eventosReservasRoutes = require('./routes/eventos_reservas');
 
 // Importar middleware de autenticação
 const { authenticateToken } = require('./middleware/auth');
@@ -96,6 +97,7 @@ app.use('/users', authenticateToken, usersRoutes);
 app.use('/restaurantes', authenticateToken, restaurantesRoutes);
 app.use('/eventos', authenticateToken, eventosRoutes);
 app.use('/reservas', authenticateToken, reservasRoutes);
+app.use('/eventos-reservas', authenticateToken, eventosReservasRoutes);
 
 // Rota para servir arquivos estáticos (se necessário)
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));


### PR DESCRIPTION
## Summary
- add data model for event-reservation join table
- create CRUD API for linking events and reservations
- register event reservation routes in main server

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689679ef2d3c832ea75819773b6b9e73