### PR TITLE
Enforce reservation and event limits

### DIFF
--- a/backend/routes/eventos.js
+++ b/backend/routes/eventos.js
@@ -193,14 +193,19 @@ router.post('/:id/marcar', async (req, res, next) => {
     }
 
     const { rows: [reserva] } = await db.query(
-      'SELECT id, data_checkin, data_checkout FROM reservas WHERE id = ?',
+      'SELECT id, nome_hospede, data_checkin, data_checkout, qtd_hospedes FROM reservas WHERE id = ?',
       [reservaId]
     );
     if (!reserva) {
       return next(new ApiError(404, 'Reserva não encontrada', 'RESERVA_NOT_FOUND'));
     }
 
-    // Rule 1: quantidade não pode ultrapassar vagas disponíveis
+    // Rule 1: quantidade não pode ultrapassar número de hóspedes da reserva
+    if (quantidade > reserva.qtd_hospedes) {
+      return next(new ApiError(400, 'Quantidade excede número de hóspedes da reserva', 'QUANTIDADE_EXCEDE_RESERVA'));
+    }
+
+    // Rule 2: total de hóspedes no evento não pode ultrapassar capacidade
     const { rows: [ocup] } = await db.query(
       `SELECT COALESCE(SUM(quantidade),0) AS total
          FROM eventos_reservas
@@ -212,7 +217,19 @@ router.post('/:id/marcar', async (req, res, next) => {
       return next(new ApiError(400, 'Capacidade do evento excedida', 'CAPACIDADE_EXCEDIDA'));
     }
 
-    // Rule 2: mesma reserva não pode ser vinculada a mais de um evento no mesmo dia
+    // Rule 3: não pode existir reserva do mesmo hóspede para o mesmo evento
+    const { rows: guestConflict } = await db.query(
+      `SELECT 1
+         FROM eventos_reservas er
+         JOIN reservas r ON er.reserva_id = r.id
+        WHERE er.evento_id = ? AND r.nome_hospede = ?`,
+      [id, reserva.nome_hospede]
+    );
+    if (guestConflict.length > 0) {
+      return next(new ApiError(400, 'Hóspede já possui reserva para este evento', 'HOSPEDE_DUPLICADO'));
+    }
+
+    // Rule 4: mesma reserva não pode ser vinculada a mais de um evento no mesmo dia
     const { rows: conflitos } = await db.query(
       `SELECT 1
          FROM eventos_reservas er
@@ -225,7 +242,7 @@ router.post('/:id/marcar', async (req, res, next) => {
       return next(new ApiError(400, 'Reserva já vinculada a outro evento neste dia', 'RESERVA_DUPLICADA'));
     }
 
-    // Rule 3: limite de marcações conforme duração da reserva
+    // Rule 5: limite de marcações conforme duração da reserva
     const checkin = new Date(reserva.data_checkin);
     const checkout = new Date(reserva.data_checkout);
     const diff = Math.max(1, Math.ceil((checkout - checkin) / (1000 * 60 * 60 * 24)));

--- a/backend/routes/eventos_reservas.js
+++ b/backend/routes/eventos_reservas.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { ApiError } = require('../middleware/errorHandler');
+const { getDatabase } = require('../config/database');
 const model = require('../models/eventoReservaModel');
 
 const router = express.Router();
@@ -41,6 +42,74 @@ router.post('/', async (req, res, next) => {
     return next(new ApiError(400, 'Dados inválidos', 'INVALID_FIELDS'));
   }
   try {
+    const db = getDatabase();
+
+    const { rows: [evento] } = await db.query(
+      `SELECT e.data_evento, r.capacidade
+         FROM eventos e
+         JOIN restaurantes r ON e.id_restaurante = r.id
+        WHERE e.id = ?`,
+      [eventoId]
+    );
+    if (!evento) {
+      return next(new ApiError(404, 'Evento não encontrado', 'EVENT_NOT_FOUND'));
+    }
+
+    const { rows: [reserva] } = await db.query(
+      'SELECT id, nome_hospede, data_checkin, data_checkout, qtd_hospedes FROM reservas WHERE id = ?',
+      [reservaId]
+    );
+    if (!reserva) {
+      return next(new ApiError(404, 'Reserva não encontrada', 'RESERVA_NOT_FOUND'));
+    }
+
+    // Rule 1: quantidade não pode ultrapassar número de hóspedes da reserva
+    if (quantidade > reserva.qtd_hospedes) {
+      return next(new ApiError(400, 'Quantidade excede número de hóspedes da reserva', 'QUANTIDADE_EXCEDE_RESERVA'));
+    }
+
+    // Rule 2: total de hóspedes no evento não pode ultrapassar capacidade
+    const { rows: [ocup] } = await db.query(
+      `SELECT COALESCE(SUM(quantidade),0) AS total
+         FROM eventos_reservas
+        WHERE evento_id = ?`,
+      [eventoId]
+    );
+    const vagas = evento.capacidade - Number(ocup.total);
+    if (quantidade > vagas) {
+      return next(new ApiError(400, 'Capacidade do evento excedida', 'CAPACIDADE_EXCEDIDA'));
+    }
+
+    // Rule 3: não pode existir reserva do mesmo hóspede para o mesmo evento
+    const { rows: guestConflict } = await db.query(
+      `SELECT 1
+         FROM eventos_reservas er
+         JOIN reservas r ON er.reserva_id = r.id
+        WHERE er.evento_id = ? AND r.nome_hospede = ?`,
+      [eventoId, reserva.nome_hospede]
+    );
+    if (guestConflict.length > 0) {
+      return next(new ApiError(400, 'Hóspede já possui reserva para este evento', 'HOSPEDE_DUPLICADO'));
+    }
+
+    // Rule 4: limite de marcações conforme duração da reserva
+    const checkin = new Date(reserva.data_checkin);
+    const checkout = new Date(reserva.data_checkout);
+    const diff = Math.max(1, Math.ceil((checkout - checkin) / (1000 * 60 * 60 * 24)));
+    let limite = 1;
+    if (diff >= 7) {
+      limite = 3;
+    } else if (diff >= 3) {
+      limite = 2;
+    }
+    const { rows: [countRes] } = await db.query(
+      'SELECT COUNT(*)::int AS count FROM eventos_reservas WHERE reserva_id = ?',
+      [reservaId]
+    );
+    if (countRes.count >= limite) {
+      return next(new ApiError(400, 'Limite de marcações atingido para a reserva', 'LIMITE_MARCACOES'));
+    }
+
     const created = await model.create({ eventoId, reservaId, informacoes, quantidade, status });
     res.status(201).json(created);
   } catch (err) {
@@ -66,6 +135,44 @@ router.put('/:eventoId/:reservaId', async (req, res, next) => {
     return next(new ApiError(400, 'quantidade inválida', 'INVALID_QUANTIDADE'));
   }
   try {
+    const db = getDatabase();
+
+    if (quantidade !== undefined) {
+      const { rows: [evento] } = await db.query(
+        `SELECT r.capacidade
+           FROM eventos e
+           JOIN restaurantes r ON e.id_restaurante = r.id
+          WHERE e.id = ?`,
+        [eventoId]
+      );
+      if (!evento) {
+        return next(new ApiError(404, 'Evento não encontrado', 'EVENT_NOT_FOUND'));
+      }
+
+      const { rows: [reserva] } = await db.query(
+        'SELECT qtd_hospedes FROM reservas WHERE id = ?',
+        [reservaId]
+      );
+      if (!reserva) {
+        return next(new ApiError(404, 'Reserva não encontrada', 'RESERVA_NOT_FOUND'));
+      }
+
+      if (quantidade > reserva.qtd_hospedes) {
+        return next(new ApiError(400, 'Quantidade excede número de hóspedes da reserva', 'QUANTIDADE_EXCEDE_RESERVA'));
+      }
+
+      const { rows: [ocup] } = await db.query(
+        `SELECT COALESCE(SUM(quantidade),0) AS total
+           FROM eventos_reservas
+          WHERE evento_id = ? AND reserva_id <> ?`,
+        [eventoId, reservaId]
+      );
+      const vagas = evento.capacidade - Number(ocup.total);
+      if (quantidade > vagas) {
+        return next(new ApiError(400, 'Capacidade do evento excedida', 'CAPACIDADE_EXCEDIDA'));
+      }
+    }
+
     const updated = await model.update(eventoId, reservaId, { informacoes, quantidade, status });
     if (updated === 0) {
       return next(new ApiError(404, 'Marcação não encontrada', 'MARCACAO_NOT_FOUND'));


### PR DESCRIPTION
## Summary
- validate reservation capacity against guest count when marking events
- prevent duplicate event bookings for the same guest and enforce restaurant capacity
- limit event markings per reservation according to stay length

## Testing
- `cd backend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689758be8ce8832e8171b0476364c5bc