### PR TITLE
Show colored status tags and actions in event reservation screen

### DIFF
--- a/frontend/src/app/components/reserva-evento/reserva-evento.html
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.html
@@ -31,21 +31,56 @@
       Não foi encontrada nenhuma reserva ativa para o código da UH informado: <b>{{reservaSelecionada}}</b>.
     </p-message>
 
-     <div *ngIf="marcacoesExistentes.length > 0" class="marcacoes-existentes">
+    <div *ngIf="marcacoesExistentes.length > 0" class="marcacoes-existentes">
       <p-message severity="info" text="Marcações desta reserva:"></p-message>
-      <div class="marcacao-item" 
+      <div
+        class="marcacao-item"
         *ngFor="let marcacao of marcacoesExistentes"
       >
-        <small>{{ marcacao.data_evento | date:'dd/MM/yyyy' }} - {{ marcacao.evento_nome }} ({{ marcacao.quantidade }} pessoas)</small>
-        <p-select
-          [(ngModel)]="marcacao.status"
-          [options]="statusOptions"
-          optionLabel="label"
-          optionValue="value"
-          (onChange)="atualizarStatus(marcacao)"
-          placeholder="Status"
-        ></p-select>
-        <button pButton type="button" label="Imprimir Voucher" icon="pi pi-print" class="p-button-text" (click)="abrirVoucher(marcacao)"></button>
+        <div class="marcacao-info">
+          <small>
+            {{ marcacao.data_evento | date:'dd/MM/yyyy' }} -
+            {{ marcacao.evento_nome }} ({{ marcacao.quantidade }} pessoas)
+          </small>
+          <p-tag
+            [value]="marcacao.status"
+            [severity]="getTagSeverity(marcacao.status)"
+          ></p-tag>
+        </div>
+        <div class="marcacao-actions">
+          <button
+            pButton
+            type="button"
+            icon="pi pi-check"
+            class="p-button-rounded p-button-success"
+            (click)="atualizarStatus(marcacao, 'Finalizada')"
+            title="Compareceu"
+          ></button>
+          <button
+            pButton
+            type="button"
+            icon="pi pi-times"
+            class="p-button-rounded p-button-danger"
+            (click)="atualizarStatus(marcacao, 'Cancelada')"
+            title="Cancelado"
+          ></button>
+          <button
+            pButton
+            type="button"
+            icon="pi pi-user-minus"
+            class="p-button-rounded p-button-warning"
+            (click)="atualizarStatus(marcacao, 'Não Compareceu')"
+            title="Não Compareceu"
+          ></button>
+          <button
+            pButton
+            type="button"
+            label="Imprimir Voucher"
+            icon="pi pi-print"
+            class="p-button-text"
+            (click)="abrirVoucher(marcacao)"
+          ></button>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/app/components/reserva-evento/reserva-evento.scss
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.scss
@@ -122,6 +122,24 @@
   background: #ffffff;
   border-radius: 4px;
   border-left: 3px solid #007bff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.marcacao-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.marcacao-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/app/components/reserva-evento/reserva-evento.ts
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.ts
@@ -13,6 +13,7 @@ import { ChartModule } from 'primeng/chart';
 import { CardModule } from 'primeng/card';
 import { DatePickerModule } from 'primeng/datepicker';
 import { MessageModule } from 'primeng/message';
+import { TagModule } from 'primeng/tag';
 import { MessageService } from 'primeng/api';
 
 import { ReservaEventoService, Reserva, Evento, Disponibilidade } from '../../services/reserva-evento.service';
@@ -33,6 +34,7 @@ import { ReservaEventoService, Reserva, Evento, Disponibilidade } from '../../se
     CardModule,
     DatePickerModule,
     MessageModule,
+    TagModule,
   ],
   providers: [MessageService],
   templateUrl: './reserva-evento.html',
@@ -50,13 +52,6 @@ export class ReservaEventoComponent {
   disponibilidade?: Disponibilidade;
   chartData?: any;
   marcacoesExistentes: any[] = [];
-
-  statusOptions = [
-    { label: 'Ativa', value: 'Ativa' },
-    { label: 'Finalizada', value: 'Finalizada' },
-    { label: 'Cancelada', value: 'Cancelada' },
-    { label: 'Não Compareceu', value: 'Não Compareceu' },
-  ];
 
   informacoes = '';
   quantidade?: number;
@@ -167,13 +162,13 @@ export class ReservaEventoComponent {
     });
   }
 
-  atualizarStatus(marcacao: any): void {
-    if (!marcacao?.evento_id || !marcacao?.reserva_id || !marcacao?.status) {
+  atualizarStatus(marcacao: any, status: string): void {
+    if (!marcacao?.evento_id || !marcacao?.reserva_id) {
       return;
     }
 
     this.service
-      .atualizarStatus(marcacao.evento_id, marcacao.reserva_id, marcacao.status)
+      .atualizarStatus(marcacao.evento_id, marcacao.reserva_id, status)
       .subscribe({
         next: () => {
           this.message.add({ severity: 'success', summary: 'Sucesso', detail: 'Status atualizado' });
@@ -184,6 +179,20 @@ export class ReservaEventoComponent {
           this.message.add({ severity: 'error', summary: 'Erro', detail });
         },
       });
+  }
+
+  getTagSeverity(status: string): string {
+    switch ((status || '').toLowerCase()) {
+      case 'finalizada':
+        return 'success';
+      case 'cancelada':
+        return 'danger';
+      case 'não compareceu':
+      case 'nao compareceu':
+        return 'warning';
+      default:
+        return 'info';
+    }
   }
 
   private validarRegrasNegocio(): { valido: boolean; mensagem: string } {


### PR DESCRIPTION
## Summary
- display colored status tag for each reservation's marking
- add buttons to mark reservation as attended, cancelled or no-show
- style markup and logic for new status controls

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68975e8fa7ec832e9cbd9011ab669cb0