### PR TITLE
Allow rebooking after cancellation

### DIFF
--- a/backend/routes/eventos.js
+++ b/backend/routes/eventos.js
@@ -292,7 +292,9 @@ router.post('/:id/marcar', async (req, res, next) => {
       `SELECT 1
          FROM eventos_reservas er
          JOIN reservas r ON er.reserva_id = r.id
-        WHERE er.evento_id = ? AND r.nome_hospede = ?`,
+        WHERE er.evento_id = ?
+          AND r.nome_hospede = ?
+          AND er.status <> 'Cancelada'`,
       [id, reserva.nome_hospede]
     );
     if (guestConflict.length > 0) {

--- a/backend/routes/eventos_reservas.js
+++ b/backend/routes/eventos_reservas.js
@@ -85,7 +85,9 @@ router.post('/', async (req, res, next) => {
       `SELECT 1
          FROM eventos_reservas er
          JOIN reservas r ON er.reserva_id = r.id
-        WHERE er.evento_id = ? AND r.nome_hospede = ?`,
+        WHERE er.evento_id = ?
+          AND r.nome_hospede = ?
+          AND er.status <> 'Cancelada'`,
       [eventoId, reserva.nome_hospede]
     );
     if (guestConflict.length > 0) {


### PR DESCRIPTION
## Summary
- permit guests to rebook events when their previous booking was canceled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68976a65e7d0832eaeb6243f7dfcffab