### PR TITLE
docs: expand swagger documentation

### DIFF
--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -25,9 +25,7 @@
       "get": {
         "summary": "Verificar status do servidor",
         "responses": {
-          "200": {
-            "description": "Status de funcionamento do servidor"
-          }
+          "200": { "description": "Status de funcionamento do servidor" }
         }
       }
     },
@@ -55,13 +53,99 @@
         }
       }
     },
+    "/auth/refresh": {
+      "post": {
+        "summary": "Renovar token de acesso usando refresh token",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "refreshToken": { "type": "string" }
+                },
+                "required": ["refreshToken"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Token renovado" },
+          "401": { "description": "Refresh token inválido" }
+        }
+      }
+    },
     "/auth/logout": {
       "post": {
         "summary": "Logout do usuário",
         "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "refreshToken": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": { "description": "Logout realizado com sucesso" },
           "401": { "description": "Usuário não autorizado" }
+        }
+      }
+    },
+    "/auth/register": {
+      "post": {
+        "summary": "Registrar novo usuário",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": { "type": "string" },
+                  "email": { "type": "string", "format": "email" },
+                  "password": { "type": "string" },
+                  "fullName": { "type": "string" }
+                },
+                "required": ["username", "email", "password"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Usuário criado" },
+          "409": { "description": "Usuário ou email já existe" }
+        }
+      }
+    },
+    "/auth/reset-password": {
+      "post": {
+        "summary": "Redefinir senha do usuário",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": { "type": "string", "format": "email" },
+                  "password": { "type": "string" }
+                },
+                "required": ["email", "password"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Senha atualizada" },
+          "404": { "description": "Usuário não encontrado" }
         }
       }
     },
@@ -75,33 +159,534 @@
         }
       }
     },
+    "/dashboard/stats": {
+      "get": {
+        "summary": "Obter estatísticas detalhadas",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": { "description": "Estatísticas obtidas" },
+          "401": { "description": "Usuário não autorizado" }
+        }
+      }
+    },
+    "/dashboard/profile": {
+      "get": {
+        "summary": "Obter perfil do usuário",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": { "description": "Perfil obtido" },
+          "401": { "description": "Usuário não autorizado" }
+        }
+      },
+      "put": {
+        "summary": "Atualizar perfil do usuário",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fullName": { "type": "string" },
+                  "email": { "type": "string", "format": "email" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Perfil atualizado" },
+          "400": { "description": "Dados inválidos" },
+          "401": { "description": "Usuário não autorizado" }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "summary": "Listar usuários",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "page", "in": "query", "schema": { "type": "integer" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Lista de usuários" }
+        }
+      },
+      "post": {
+        "summary": "Criar usuário",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": { "type": "string" },
+                  "email": { "type": "string", "format": "email" },
+                  "password": { "type": "string" },
+                  "fullName": { "type": "string" }
+                },
+                "required": ["username", "email", "password"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Usuário criado" },
+          "409": { "description": "Usuário ou email já existe" }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "summary": "Obter usuário pelo ID",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Usuário encontrado" },
+          "404": { "description": "Usuário não encontrado" }
+        }
+      },
+      "put": {
+        "summary": "Atualizar usuário",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": { "type": "string" },
+                  "email": { "type": "string", "format": "email" },
+                  "fullName": { "type": "string" },
+                  "is_active": { "type": "boolean" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Usuário atualizado" },
+          "404": { "description": "Usuário não encontrado" }
+        }
+      },
+      "delete": {
+        "summary": "Desativar usuário",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Usuário desativado" },
+          "404": { "description": "Usuário não encontrado" }
+        }
+      }
+    },
+    "/restaurantes": {
+      "get": {
+        "summary": "Listar restaurantes",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "page", "in": "query", "schema": { "type": "integer" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Lista de restaurantes" } }
+      },
+      "post": {
+        "summary": "Criar restaurante",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nome": { "type": "string" },
+                  "capacidade": { "type": "integer" },
+                  "horario_funcionamento": { "type": "string" }
+                },
+                "required": ["nome", "capacidade", "horario_funcionamento"]
+              }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Restaurante criado" } }
+      }
+    },
+    "/restaurantes/{id}": {
+      "get": {
+        "summary": "Obter restaurante pelo ID",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Restaurante encontrado" },
+          "404": { "description": "Restaurante não encontrado" }
+        }
+      },
+      "put": {
+        "summary": "Atualizar restaurante",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nome": { "type": "string" },
+                  "capacidade": { "type": "integer" },
+                  "horario_funcionamento": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Restaurante atualizado" },
+          "404": { "description": "Restaurante não encontrado" }
+        }
+      },
+      "delete": {
+        "summary": "Deletar restaurante",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Restaurante deletado" },
+          "404": { "description": "Restaurante não encontrado" }
+        }
+      }
+    },
+    "/eventos": {
+      "get": {
+        "summary": "Listar eventos",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "data", "in": "query", "schema": { "type": "string", "format": "date" } },
+          { "name": "page", "in": "query", "schema": { "type": "integer" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Lista de eventos" } }
+      },
+      "post": {
+        "summary": "Criar evento",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nome": { "type": "string" },
+                  "data": { "type": "string", "format": "date" },
+                  "hora": { "type": "string", "pattern": "^\\d{2}:\\d{2}$" },
+                  "restauranteId": { "type": "integer" }
+                },
+                "required": ["nome", "data", "hora", "restauranteId"]
+              }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Evento criado" } }
+      }
+    },
+    "/eventos/{id}": {
+      "get": {
+        "summary": "Obter evento pelo ID",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Evento encontrado" },
+          "404": { "description": "Evento não encontrado" }
+        }
+      },
+      "put": {
+        "summary": "Atualizar evento",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nome": { "type": "string" },
+                  "data": { "type": "string", "format": "date" },
+                  "hora": { "type": "string" },
+                  "restauranteId": { "type": "integer" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Evento atualizado" },
+          "404": { "description": "Evento não encontrado" }
+        }
+      },
+      "delete": {
+        "summary": "Deletar evento",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Evento deletado" },
+          "404": { "description": "Evento não encontrado" }
+        }
+      }
+    },
+    "/eventos/{id}/disponibilidade": {
+      "get": {
+        "summary": "Verificar disponibilidade do evento",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Disponibilidade retornada" },
+          "404": { "description": "Evento não encontrado" }
+        }
+      }
+    },
+    "/eventos/{eventoId}/marcacoes/{reservaId}/status": {
+      "patch": {
+        "summary": "Atualizar status da marcação do evento",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "eventoId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "reservaId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": { "status": { "type": "string" } },
+                "required": ["status"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Status atualizado" },
+          "404": { "description": "Marcação não encontrada" }
+        }
+      }
+    },
+    "/eventos-reservas": {
+      "get": {
+        "summary": "Listar marcações de eventos",
+        "security": [{ "bearerAuth": [] }],
+        "responses": { "200": { "description": "Lista de marcações" } }
+      },
+      "post": {
+        "summary": "Criar marcação de evento",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "eventoId": { "type": "integer" },
+                  "reservaId": { "type": "integer" },
+                  "informacoes": { "type": "string" },
+                  "quantidade": { "type": "integer" },
+                  "status": { "type": "string" }
+                },
+                "required": ["eventoId", "reservaId", "quantidade"]
+              }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Marcação criada" } }
+      }
+    },
+    "/eventos-reservas/{eventoId}/{reservaId}": {
+      "get": {
+        "summary": "Obter marcação específica",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "eventoId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "reservaId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Marcação encontrada" },
+          "404": { "description": "Marcação não encontrada" }
+        }
+      },
+      "put": {
+        "summary": "Atualizar marcação",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "eventoId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "reservaId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "informacoes": { "type": "string" },
+                  "quantidade": { "type": "integer" },
+                  "status": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Marcação atualizada" },
+          "404": { "description": "Marcação não encontrada" }
+        }
+      },
+      "delete": {
+        "summary": "Remover marcação",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "eventoId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "reservaId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Marcação removida" },
+          "404": { "description": "Marcação não encontrada" }
+        }
+      }
+    },
+    "/reservas": {
+      "get": {
+        "summary": "Listar reservas",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "codigoUH", "in": "query", "schema": { "type": "string" } },
+          { "name": "hoje", "in": "query", "schema": { "type": "string", "format": "date" } },
+          { "name": "page", "in": "query", "schema": { "type": "integer" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Lista de reservas" } }
+      },
+      "post": {
+        "summary": "Criar reserva",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "idreservacm": { "type": "integer" },
+                  "numeroreservacm": { "type": "string" },
+                  "coduh": { "type": "string" },
+                  "nome_hospede": { "type": "string" },
+                  "data_checkin": { "type": "string", "format": "date" },
+                  "data_checkout": { "type": "string", "format": "date" },
+                  "qtd_hospedes": { "type": "integer" }
+                },
+                "required": ["coduh", "nome_hospede", "data_checkin", "data_checkout", "qtd_hospedes"]
+              }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Reserva criada" } }
+      }
+    },
     "/reservas/buscar": {
       "get": {
         "summary": "Buscar reserva por coduh e período",
+        "security": [{ "bearerAuth": [] }],
         "parameters": [
-          {
-            "name": "coduh",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "checkin",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "string", "format": "date" }
-          },
-          {
-            "name": "checkout",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "string", "format": "date" }
-          }
+          { "name": "coduh", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "checkin", "in": "query", "required": true, "schema": { "type": "string", "format": "date" } },
+          { "name": "checkout", "in": "query", "required": true, "schema": { "type": "string", "format": "date" } }
         ],
         "responses": {
           "200": { "description": "Reserva encontrada" },
           "404": { "description": "Reserva não encontrada" },
           "409": { "description": "Múltiplas reservas sobrepostas" }
+        }
+      }
+    },
+    "/reservas/{id}/marcacoes": {
+      "get": {
+        "summary": "Listar marcações de uma reserva",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Lista de marcações" },
+          "404": { "description": "Reserva não encontrada" }
+        }
+      }
+    },
+    "/reservas/{id}": {
+      "put": {
+        "summary": "Atualizar reserva",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "idreservacm": { "type": "integer" },
+                  "numeroreservacm": { "type": "string" },
+                  "coduh": { "type": "string" },
+                  "nome_hospede": { "type": "string" },
+                  "data_checkin": { "type": "string", "format": "date" },
+                  "data_checkout": { "type": "string", "format": "date" },
+                  "qtd_hospedes": { "type": "integer" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Reserva atualizada" },
+          "404": { "description": "Reserva não encontrada" }
+        }
+      },
+      "delete": {
+        "summary": "Deletar reserva",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Reserva deletada" },
+          "404": { "description": "Reserva não encontrada" }
         }
       }
     }


### PR DESCRIPTION
## Summary
- expand authentication docs with refresh, registration and reset flows
- document dashboard, user, restaurant, event and reservation endpoints in swagger

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68976d002314832e95aa2b26c0033ecd