### PR TITLE
docs(swagger): group routes by tag

### DIFF
--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -20,13 +20,52 @@
       }
     }
   },
+  "tags": [
+    {
+      "name": "Health",
+      "description": "Verificação de status do servidor"
+    },
+    {
+      "name": "Auth",
+      "description": "Autenticação de usuários"
+    },
+    {
+      "name": "Dashboard",
+      "description": "Operações do dashboard"
+    },
+    {
+      "name": "Users",
+      "description": "Gerenciamento de usuários"
+    },
+    {
+      "name": "Restaurantes",
+      "description": "Gerenciamento de restaurantes"
+    },
+    {
+      "name": "Eventos",
+      "description": "Gerenciamento de eventos"
+    },
+    {
+      "name": "EventosReservas",
+      "description": "Operações de relacionamento evento-reserva"
+    },
+    {
+      "name": "Reservas",
+      "description": "Gerenciamento de reservas"
+    }
+  ],
   "paths": {
     "/health": {
       "get": {
         "summary": "Verificar status do servidor",
         "responses": {
-          "200": { "description": "Status de funcionamento do servidor" }
-        }
+          "200": {
+            "description": "Status de funcionamento do servidor"
+          }
+        },
+        "tags": [
+          "Health"
+        ]
       }
     },
     "/auth/login": {
@@ -39,18 +78,32 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "username": { "type": "string" },
-                  "password": { "type": "string" }
+                  "username": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  }
                 },
-                "required": ["username", "password"]
+                "required": [
+                  "username",
+                  "password"
+                ]
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Login realizado com sucesso" },
-          "401": { "description": "Credenciais inválidas" }
-        }
+          "200": {
+            "description": "Login realizado com sucesso"
+          },
+          "401": {
+            "description": "Credenciais inválidas"
+          }
+        },
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/refresh": {
@@ -63,23 +116,38 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "refreshToken": { "type": "string" }
+                  "refreshToken": {
+                    "type": "string"
+                  }
                 },
-                "required": ["refreshToken"]
+                "required": [
+                  "refreshToken"
+                ]
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Token renovado" },
-          "401": { "description": "Refresh token inválido" }
-        }
+          "200": {
+            "description": "Token renovado"
+          },
+          "401": {
+            "description": "Refresh token inválido"
+          }
+        },
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/logout": {
       "post": {
         "summary": "Logout do usuário",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": false,
           "content": {
@@ -87,16 +155,25 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "refreshToken": { "type": "string" }
+                  "refreshToken": {
+                    "type": "string"
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Logout realizado com sucesso" },
-          "401": { "description": "Usuário não autorizado" }
-        }
+          "200": {
+            "description": "Logout realizado com sucesso"
+          },
+          "401": {
+            "description": "Usuário não autorizado"
+          }
+        },
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/register": {
@@ -109,20 +186,40 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "username": { "type": "string" },
-                  "email": { "type": "string", "format": "email" },
-                  "password": { "type": "string" },
-                  "fullName": { "type": "string" }
+                  "username": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "fullName": {
+                    "type": "string"
+                  }
                 },
-                "required": ["username", "email", "password"]
+                "required": [
+                  "username",
+                  "email",
+                  "password"
+                ]
               }
             }
           }
         },
         "responses": {
-          "201": { "description": "Usuário criado" },
-          "409": { "description": "Usuário ou email já existe" }
-        }
+          "201": {
+            "description": "Usuário criado"
+          },
+          "409": {
+            "description": "Usuário ou email já existe"
+          }
+        },
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/auth/reset-password": {
@@ -135,52 +232,104 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "email": { "type": "string", "format": "email" },
-                  "password": { "type": "string" }
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string"
+                  }
                 },
-                "required": ["email", "password"]
+                "required": [
+                  "email",
+                  "password"
+                ]
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Senha atualizada" },
-          "404": { "description": "Usuário não encontrado" }
-        }
+          "200": {
+            "description": "Senha atualizada"
+          },
+          "404": {
+            "description": "Usuário não encontrado"
+          }
+        },
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/dashboard": {
       "get": {
         "summary": "Obter dados do dashboard",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
-          "200": { "description": "Dados do dashboard" },
-          "401": { "description": "Usuário não autorizado" }
-        }
+          "200": {
+            "description": "Dados do dashboard"
+          },
+          "401": {
+            "description": "Usuário não autorizado"
+          }
+        },
+        "tags": [
+          "Dashboard"
+        ]
       }
     },
     "/dashboard/stats": {
       "get": {
         "summary": "Obter estatísticas detalhadas",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
-          "200": { "description": "Estatísticas obtidas" },
-          "401": { "description": "Usuário não autorizado" }
-        }
+          "200": {
+            "description": "Estatísticas obtidas"
+          },
+          "401": {
+            "description": "Usuário não autorizado"
+          }
+        },
+        "tags": [
+          "Dashboard"
+        ]
       }
     },
     "/dashboard/profile": {
       "get": {
         "summary": "Obter perfil do usuário",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "responses": {
-          "200": { "description": "Perfil obtido" },
-          "401": { "description": "Usuário não autorizado" }
-        }
+          "200": {
+            "description": "Perfil obtido"
+          },
+          "401": {
+            "description": "Usuário não autorizado"
+          }
+        },
+        "tags": [
+          "Dashboard"
+        ]
       },
       "put": {
         "summary": "Atualizar perfil do usuário",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -188,35 +337,74 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "fullName": { "type": "string" },
-                  "email": { "type": "string", "format": "email" }
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Perfil atualizado" },
-          "400": { "description": "Dados inválidos" },
-          "401": { "description": "Usuário não autorizado" }
-        }
+          "200": {
+            "description": "Perfil atualizado"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Usuário não autorizado"
+          }
+        },
+        "tags": [
+          "Dashboard"
+        ]
       }
     },
     "/users": {
       "get": {
         "summary": "Listar usuários",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "page", "in": "query", "schema": { "type": "integer" } },
-          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Lista de usuários" }
-        }
+          "200": {
+            "description": "Lista de usuários"
+          }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "post": {
         "summary": "Criar usuário",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -224,39 +412,88 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "username": { "type": "string" },
-                  "email": { "type": "string", "format": "email" },
-                  "password": { "type": "string" },
-                  "fullName": { "type": "string" }
+                  "username": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "fullName": {
+                    "type": "string"
+                  }
                 },
-                "required": ["username", "email", "password"]
+                "required": [
+                  "username",
+                  "email",
+                  "password"
+                ]
               }
             }
           }
         },
         "responses": {
-          "201": { "description": "Usuário criado" },
-          "409": { "description": "Usuário ou email já existe" }
-        }
+          "201": {
+            "description": "Usuário criado"
+          },
+          "409": {
+            "description": "Usuário ou email já existe"
+          }
+        },
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/users/{id}": {
       "get": {
         "summary": "Obter usuário pelo ID",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Usuário encontrado" },
-          "404": { "description": "Usuário não encontrado" }
-        }
+          "200": {
+            "description": "Usuário encontrado"
+          },
+          "404": {
+            "description": "Usuário não encontrado"
+          }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "put": {
         "summary": "Atualizar usuário",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -265,45 +502,106 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "username": { "type": "string" },
-                  "email": { "type": "string", "format": "email" },
-                  "fullName": { "type": "string" },
-                  "is_active": { "type": "boolean" }
+                  "username": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "is_active": {
+                    "type": "boolean"
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Usuário atualizado" },
-          "404": { "description": "Usuário não encontrado" }
-        }
+          "200": {
+            "description": "Usuário atualizado"
+          },
+          "404": {
+            "description": "Usuário não encontrado"
+          }
+        },
+        "tags": [
+          "Users"
+        ]
       },
       "delete": {
         "summary": "Desativar usuário",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Usuário desativado" },
-          "404": { "description": "Usuário não encontrado" }
-        }
+          "200": {
+            "description": "Usuário desativado"
+          },
+          "404": {
+            "description": "Usuário não encontrado"
+          }
+        },
+        "tags": [
+          "Users"
+        ]
       }
     },
     "/restaurantes": {
       "get": {
         "summary": "Listar restaurantes",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [
-          { "name": "page", "in": "query", "schema": { "type": "integer" } },
-          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ],
-        "responses": { "200": { "description": "Lista de restaurantes" } }
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista de restaurantes"
+          }
+        },
+        "tags": [
+          "Restaurantes"
+        ]
       },
       "post": {
         "summary": "Criar restaurante",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -311,35 +609,81 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "nome": { "type": "string" },
-                  "capacidade": { "type": "integer" },
-                  "horario_funcionamento": { "type": "string" }
+                  "nome": {
+                    "type": "string"
+                  },
+                  "capacidade": {
+                    "type": "integer"
+                  },
+                  "horario_funcionamento": {
+                    "type": "string"
+                  }
                 },
-                "required": ["nome", "capacidade", "horario_funcionamento"]
+                "required": [
+                  "nome",
+                  "capacidade",
+                  "horario_funcionamento"
+                ]
               }
             }
           }
         },
-        "responses": { "201": { "description": "Restaurante criado" } }
+        "responses": {
+          "201": {
+            "description": "Restaurante criado"
+          }
+        },
+        "tags": [
+          "Restaurantes"
+        ]
       }
     },
     "/restaurantes/{id}": {
       "get": {
         "summary": "Obter restaurante pelo ID",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Restaurante encontrado" },
-          "404": { "description": "Restaurante não encontrado" }
-        }
+          "200": {
+            "description": "Restaurante encontrado"
+          },
+          "404": {
+            "description": "Restaurante não encontrado"
+          }
+        },
+        "tags": [
+          "Restaurantes"
+        ]
       },
       "put": {
         "summary": "Atualizar restaurante",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -348,45 +692,110 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "nome": { "type": "string" },
-                  "capacidade": { "type": "integer" },
-                  "horario_funcionamento": { "type": "string" }
+                  "nome": {
+                    "type": "string"
+                  },
+                  "capacidade": {
+                    "type": "integer"
+                  },
+                  "horario_funcionamento": {
+                    "type": "string"
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Restaurante atualizado" },
-          "404": { "description": "Restaurante não encontrado" }
-        }
+          "200": {
+            "description": "Restaurante atualizado"
+          },
+          "404": {
+            "description": "Restaurante não encontrado"
+          }
+        },
+        "tags": [
+          "Restaurantes"
+        ]
       },
       "delete": {
         "summary": "Deletar restaurante",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Restaurante deletado" },
-          "404": { "description": "Restaurante não encontrado" }
-        }
+          "200": {
+            "description": "Restaurante deletado"
+          },
+          "404": {
+            "description": "Restaurante não encontrado"
+          }
+        },
+        "tags": [
+          "Restaurantes"
+        ]
       }
     },
     "/eventos": {
       "get": {
         "summary": "Listar eventos",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [
-          { "name": "data", "in": "query", "schema": { "type": "string", "format": "date" } },
-          { "name": "page", "in": "query", "schema": { "type": "integer" } },
-          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ],
-        "responses": { "200": { "description": "Lista de eventos" } }
+        "parameters": [
+          {
+            "name": "data",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista de eventos"
+          }
+        },
+        "tags": [
+          "Eventos"
+        ]
       },
       "post": {
         "summary": "Criar evento",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -394,36 +803,87 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "nome": { "type": "string" },
-                  "data": { "type": "string", "format": "date" },
-                  "hora": { "type": "string", "pattern": "^\\d{2}:\\d{2}$" },
-                  "restauranteId": { "type": "integer" }
+                  "nome": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "hora": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
+                  },
+                  "restauranteId": {
+                    "type": "integer"
+                  }
                 },
-                "required": ["nome", "data", "hora", "restauranteId"]
+                "required": [
+                  "nome",
+                  "data",
+                  "hora",
+                  "restauranteId"
+                ]
               }
             }
           }
         },
-        "responses": { "201": { "description": "Evento criado" } }
+        "responses": {
+          "201": {
+            "description": "Evento criado"
+          }
+        },
+        "tags": [
+          "Eventos"
+        ]
       }
     },
     "/eventos/{id}": {
       "get": {
         "summary": "Obter evento pelo ID",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Evento encontrado" },
-          "404": { "description": "Evento não encontrado" }
-        }
+          "200": {
+            "description": "Evento encontrado"
+          },
+          "404": {
+            "description": "Evento não encontrado"
+          }
+        },
+        "tags": [
+          "Eventos"
+        ]
       },
       "put": {
         "summary": "Atualizar evento",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -432,52 +892,122 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "nome": { "type": "string" },
-                  "data": { "type": "string", "format": "date" },
-                  "hora": { "type": "string" },
-                  "restauranteId": { "type": "integer" }
+                  "nome": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "hora": {
+                    "type": "string"
+                  },
+                  "restauranteId": {
+                    "type": "integer"
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Evento atualizado" },
-          "404": { "description": "Evento não encontrado" }
-        }
+          "200": {
+            "description": "Evento atualizado"
+          },
+          "404": {
+            "description": "Evento não encontrado"
+          }
+        },
+        "tags": [
+          "Eventos"
+        ]
       },
       "delete": {
         "summary": "Deletar evento",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Evento deletado" },
-          "404": { "description": "Evento não encontrado" }
-        }
+          "200": {
+            "description": "Evento deletado"
+          },
+          "404": {
+            "description": "Evento não encontrado"
+          }
+        },
+        "tags": [
+          "Eventos"
+        ]
       }
     },
     "/eventos/{id}/disponibilidade": {
       "get": {
         "summary": "Verificar disponibilidade do evento",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Disponibilidade retornada" },
-          "404": { "description": "Evento não encontrado" }
-        }
+          "200": {
+            "description": "Disponibilidade retornada"
+          },
+          "404": {
+            "description": "Evento não encontrado"
+          }
+        },
+        "tags": [
+          "Eventos"
+        ]
       }
     },
     "/eventos/{eventoId}/marcacoes/{reservaId}/status": {
       "patch": {
         "summary": "Atualizar status da marcação do evento",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "eventoId", "in": "path", "required": true, "schema": { "type": "integer" } },
-          { "name": "reservaId", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "eventoId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "reservaId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -485,27 +1015,55 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": { "status": { "type": "string" } },
-                "required": ["status"]
+                "properties": {
+                  "status": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "status"
+                ]
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Status atualizado" },
-          "404": { "description": "Marcação não encontrada" }
-        }
+          "200": {
+            "description": "Status atualizado"
+          },
+          "404": {
+            "description": "Marcação não encontrada"
+          }
+        },
+        "tags": [
+          "Eventos"
+        ]
       }
     },
     "/eventos-reservas": {
       "get": {
         "summary": "Listar marcações de eventos",
-        "security": [{ "bearerAuth": [] }],
-        "responses": { "200": { "description": "Lista de marcações" } }
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista de marcações"
+          }
+        },
+        "tags": [
+          "EventosReservas"
+        ]
       },
       "post": {
         "summary": "Criar marcação de evento",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -513,39 +1071,103 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "eventoId": { "type": "integer" },
-                  "reservaId": { "type": "integer" },
-                  "informacoes": { "type": "string" },
-                  "quantidade": { "type": "integer" },
-                  "status": { "type": "string" }
+                  "eventoId": {
+                    "type": "integer"
+                  },
+                  "reservaId": {
+                    "type": "integer"
+                  },
+                  "informacoes": {
+                    "type": "string"
+                  },
+                  "quantidade": {
+                    "type": "integer"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
                 },
-                "required": ["eventoId", "reservaId", "quantidade"]
+                "required": [
+                  "eventoId",
+                  "reservaId",
+                  "quantidade"
+                ]
               }
             }
           }
         },
-        "responses": { "201": { "description": "Marcação criada" } }
+        "responses": {
+          "201": {
+            "description": "Marcação criada"
+          }
+        },
+        "tags": [
+          "EventosReservas"
+        ]
       }
     },
     "/eventos-reservas/{eventoId}/{reservaId}": {
       "get": {
         "summary": "Obter marcação específica",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "eventoId", "in": "path", "required": true, "schema": { "type": "integer" } },
-          { "name": "reservaId", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "eventoId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "reservaId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Marcação encontrada" },
-          "404": { "description": "Marcação não encontrada" }
-        }
+          "200": {
+            "description": "Marcação encontrada"
+          },
+          "404": {
+            "description": "Marcação não encontrada"
+          }
+        },
+        "tags": [
+          "EventosReservas"
+        ]
       },
       "put": {
         "summary": "Atualizar marcação",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "eventoId", "in": "path", "required": true, "schema": { "type": "integer" } },
-          { "name": "reservaId", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "eventoId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "reservaId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -554,47 +1176,125 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "informacoes": { "type": "string" },
-                  "quantidade": { "type": "integer" },
-                  "status": { "type": "string" }
+                  "informacoes": {
+                    "type": "string"
+                  },
+                  "quantidade": {
+                    "type": "integer"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Marcação atualizada" },
-          "404": { "description": "Marcação não encontrada" }
-        }
+          "200": {
+            "description": "Marcação atualizada"
+          },
+          "404": {
+            "description": "Marcação não encontrada"
+          }
+        },
+        "tags": [
+          "EventosReservas"
+        ]
       },
       "delete": {
         "summary": "Remover marcação",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "eventoId", "in": "path", "required": true, "schema": { "type": "integer" } },
-          { "name": "reservaId", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "eventoId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "reservaId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Marcação removida" },
-          "404": { "description": "Marcação não encontrada" }
-        }
+          "200": {
+            "description": "Marcação removida"
+          },
+          "404": {
+            "description": "Marcação não encontrada"
+          }
+        },
+        "tags": [
+          "EventosReservas"
+        ]
       }
     },
     "/reservas": {
       "get": {
         "summary": "Listar reservas",
-        "security": [{ "bearerAuth": [] }],
-        "parameters": [
-          { "name": "codigoUH", "in": "query", "schema": { "type": "string" } },
-          { "name": "hoje", "in": "query", "schema": { "type": "string", "format": "date" } },
-          { "name": "page", "in": "query", "schema": { "type": "integer" } },
-          { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ],
-        "responses": { "200": { "description": "Lista de reservas" } }
+        "parameters": [
+          {
+            "name": "codigoUH",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "hoje",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista de reservas"
+          }
+        },
+        "tags": [
+          "Reservas"
+        ]
       },
       "post": {
         "summary": "Criar reserva",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -602,57 +1302,151 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "idreservacm": { "type": "integer" },
-                  "numeroreservacm": { "type": "string" },
-                  "coduh": { "type": "string" },
-                  "nome_hospede": { "type": "string" },
-                  "data_checkin": { "type": "string", "format": "date" },
-                  "data_checkout": { "type": "string", "format": "date" },
-                  "qtd_hospedes": { "type": "integer" }
+                  "idreservacm": {
+                    "type": "integer"
+                  },
+                  "numeroreservacm": {
+                    "type": "string"
+                  },
+                  "coduh": {
+                    "type": "string"
+                  },
+                  "nome_hospede": {
+                    "type": "string"
+                  },
+                  "data_checkin": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "data_checkout": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "qtd_hospedes": {
+                    "type": "integer"
+                  }
                 },
-                "required": ["coduh", "nome_hospede", "data_checkin", "data_checkout", "qtd_hospedes"]
+                "required": [
+                  "coduh",
+                  "nome_hospede",
+                  "data_checkin",
+                  "data_checkout",
+                  "qtd_hospedes"
+                ]
               }
             }
           }
         },
-        "responses": { "201": { "description": "Reserva criada" } }
+        "responses": {
+          "201": {
+            "description": "Reserva criada"
+          }
+        },
+        "tags": [
+          "Reservas"
+        ]
       }
     },
     "/reservas/buscar": {
       "get": {
         "summary": "Buscar reserva por coduh e período",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "coduh", "in": "query", "required": true, "schema": { "type": "string" } },
-          { "name": "checkin", "in": "query", "required": true, "schema": { "type": "string", "format": "date" } },
-          { "name": "checkout", "in": "query", "required": true, "schema": { "type": "string", "format": "date" } }
+          {
+            "name": "coduh",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "checkin",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "checkout",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Reserva encontrada" },
-          "404": { "description": "Reserva não encontrada" },
-          "409": { "description": "Múltiplas reservas sobrepostas" }
-        }
+          "200": {
+            "description": "Reserva encontrada"
+          },
+          "404": {
+            "description": "Reserva não encontrada"
+          },
+          "409": {
+            "description": "Múltiplas reservas sobrepostas"
+          }
+        },
+        "tags": [
+          "Reservas"
+        ]
       }
     },
     "/reservas/{id}/marcacoes": {
       "get": {
         "summary": "Listar marcações de uma reserva",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Lista de marcações" },
-          "404": { "description": "Reserva não encontrada" }
-        }
+          "200": {
+            "description": "Lista de marcações"
+          },
+          "404": {
+            "description": "Reserva não encontrada"
+          }
+        },
+        "tags": [
+          "Reservas"
+        ]
       }
     },
     "/reservas/{id}": {
       "put": {
         "summary": "Atualizar reserva",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -661,33 +1455,74 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "idreservacm": { "type": "integer" },
-                  "numeroreservacm": { "type": "string" },
-                  "coduh": { "type": "string" },
-                  "nome_hospede": { "type": "string" },
-                  "data_checkin": { "type": "string", "format": "date" },
-                  "data_checkout": { "type": "string", "format": "date" },
-                  "qtd_hospedes": { "type": "integer" }
+                  "idreservacm": {
+                    "type": "integer"
+                  },
+                  "numeroreservacm": {
+                    "type": "string"
+                  },
+                  "coduh": {
+                    "type": "string"
+                  },
+                  "nome_hospede": {
+                    "type": "string"
+                  },
+                  "data_checkin": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "data_checkout": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "qtd_hospedes": {
+                    "type": "integer"
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Reserva atualizada" },
-          "404": { "description": "Reserva não encontrada" }
-        }
+          "200": {
+            "description": "Reserva atualizada"
+          },
+          "404": {
+            "description": "Reserva não encontrada"
+          }
+        },
+        "tags": [
+          "Reservas"
+        ]
       },
       "delete": {
         "summary": "Deletar reserva",
-        "security": [{ "bearerAuth": [] }],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Reserva deletada" },
-          "404": { "description": "Reserva não encontrada" }
-        }
+          "200": {
+            "description": "Reserva deletada"
+          },
+          "404": {
+            "description": "Reserva não encontrada"
+          }
+        },
+        "tags": [
+          "Reservas"
+        ]
       }
     }
   }


### PR DESCRIPTION
## Summary
- organize Swagger docs with tags for health, auth, users, reservas and other groups

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68976fc9d388832e80803cc2efda2b4f