### PR TITLE
feat: add global loading spinner for http requests

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -8,13 +8,14 @@ import Aura from '@primeuix/themes/aura';
 import { routes } from './app.routes';
 import { authInterceptor } from './interceptors/auth-interceptor';
 import { errorInterceptor } from './interceptors/error-interceptor';
+import { loadingInterceptor } from './interceptors/loading-interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient(withInterceptors([authInterceptor, errorInterceptor])),
+    provideHttpClient(withInterceptors([authInterceptor, loadingInterceptor, errorInterceptor])),
     provideAnimationsAsync(),
     providePrimeNG({ theme: { preset: Aura, options: { darkModeSelector: '.app-dark' } } }),
     MessageService

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -5,12 +5,14 @@
 
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { LoadingComponent } from './components/loading/loading';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, LoadingComponent],
   template: `
+    <app-loading></app-loading>
     <router-outlet></router-outlet>
   `,
   styles: []

--- a/frontend/src/app/components/loading/loading.html
+++ b/frontend/src/app/components/loading/loading.html
@@ -1,0 +1,3 @@
+<div class="loading-overlay" *ngIf="loading$ | async">
+  <p-progressSpinner></p-progressSpinner>
+</div>

--- a/frontend/src/app/components/loading/loading.scss
+++ b/frontend/src/app/components/loading/loading.scss
@@ -1,0 +1,12 @@
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 9999;
+}

--- a/frontend/src/app/components/loading/loading.ts
+++ b/frontend/src/app/components/loading/loading.ts
@@ -1,0 +1,15 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
+import { LoadingService } from '../../services/loading.service';
+
+@Component({
+  selector: 'app-loading',
+  standalone: true,
+  imports: [CommonModule, ProgressSpinnerModule],
+  templateUrl: './loading.html',
+  styleUrls: ['./loading.scss']
+})
+export class LoadingComponent {
+  loading$ = inject(LoadingService).loading$;
+}

--- a/frontend/src/app/interceptors/loading-interceptor.ts
+++ b/frontend/src/app/interceptors/loading-interceptor.ts
@@ -1,0 +1,10 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { finalize } from 'rxjs';
+import { LoadingService } from '../services/loading.service';
+
+export const loadingInterceptor: HttpInterceptorFn = (req, next) => {
+  const loadingService = inject(LoadingService);
+  loadingService.show();
+  return next(req).pipe(finalize(() => loadingService.hide()));
+};

--- a/frontend/src/app/services/loading.service.ts
+++ b/frontend/src/app/services/loading.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoadingService {
+  private requestCount = 0;
+  private loadingSubject = new BehaviorSubject<boolean>(false);
+  loading$ = this.loadingSubject.asObservable();
+
+  show(): void {
+    this.requestCount++;
+    if (this.requestCount === 1) {
+      this.loadingSubject.next(true);
+    }
+  }
+
+  hide(): void {
+    if (this.requestCount > 0) {
+      this.requestCount--;
+    }
+    if (this.requestCount === 0) {
+      this.loadingSubject.next(false);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add LoadingService to track active http requests
- show progress spinner overlay during pending http calls
- wire loading interceptor and component into app

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68976f4bfce4832e8243d00043d95b91