### PR TITLE
Fix event date handling

### DIFF
--- a/frontend/src/app/components/eventos/evento-list.html
+++ b/frontend/src/app/components/eventos/evento-list.html
@@ -32,7 +32,7 @@
       <tr>
         <td>{{ e.nome }}</td>
         <td>{{ e.restaurante }}</td>
-        <td>{{ e.data | date:'dd/MM/yyyy' }}</td>
+        <td>{{ e.data | date:'dd/MM/yyyy':'UTC' }}</td>
         <td>{{ e.hora }}</td>
         <td>
           <button pButton icon="pi pi-pencil" class="p-button-text" (click)="editar(e.id)"></button>

--- a/frontend/src/app/components/reserva-evento-list/reserva-evento-list.html
+++ b/frontend/src/app/components/reserva-evento-list/reserva-evento-list.html
@@ -17,7 +17,7 @@
     <ng-template pTemplate="body" let-m>
       <tr>
         <td>{{ m.evento_nome }}</td>
-        <td>{{ m.evento_data | date:'dd/MM/yyyy' }}</td>
+        <td>{{ m.evento_data | date:'dd/MM/yyyy':'UTC' }}</td>
         <td>{{ m.restaurante }}</td>
         <td>{{ m.nome_hospede }}</td>
         <td class="status-cell">

--- a/frontend/src/app/components/reserva-evento/reserva-evento.html
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.html
@@ -22,8 +22,8 @@
     <p-card *ngIf="reservaSelecionada !== undefined && (reservaSelecionada?.id ?? 0) > 0" class="reserva-info">
       <div>ID: {{ reservaSelecionada.id }}</div>
       <div>Hóspede: {{ reservaSelecionada.nome_hospede }}</div>
-      <div>Check-in: {{ reservaSelecionada.data_checkin | date:'dd/MM/yyyy'}}</div>
-      <div>Check-out: {{ reservaSelecionada.data_checkout | date:'dd/MM/yyyy'}}</div>
+      <div>Check-in: {{ reservaSelecionada.data_checkin | date:'dd/MM/yyyy':'UTC' }}</div>
+      <div>Check-out: {{ reservaSelecionada.data_checkout | date:'dd/MM/yyyy':'UTC' }}</div>
       <div>Hóspedes: {{ reservaSelecionada.qtd_hospedes }}</div>
     </p-card>
 
@@ -39,7 +39,7 @@
       >
         <div class="marcacao-info">
           <small>
-            {{ marcacao.data_evento | date:'dd/MM/yyyy' }} -
+            {{ marcacao.data_evento | date:'dd/MM/yyyy':'UTC' }} -
             {{ marcacao.evento_nome }} ({{ marcacao.quantidade }} pessoas)
           </small>
           <p-tag

--- a/frontend/src/app/components/reservas/reserva-list.html
+++ b/frontend/src/app/components/reservas/reserva-list.html
@@ -35,8 +35,8 @@
         <td>{{ r.numeroreservacm }}</td>
         <td>{{ r.coduh }}</td>
         <td>{{ r.nome_hospede }}</td>
-        <td>{{ r.data_checkin | date:'dd/MM/yyyy' }}</td>
-        <td>{{ r.data_checkout | date:'dd/MM/yyyy' }}</td>
+        <td>{{ r.data_checkin | date:'dd/MM/yyyy':'UTC' }}</td>
+        <td>{{ r.data_checkout | date:'dd/MM/yyyy':'UTC' }}</td>
         <td>{{ r.qtd_hospedes }}</td>
         <td>
           <button pButton icon="pi pi-pencil" class="p-button-text" (click)="editar(r.id)"></button>

--- a/frontend/src/app/services/eventos.ts
+++ b/frontend/src/app/services/eventos.ts
@@ -17,6 +17,10 @@ export interface Evento {
   restaurante?: string;
 }
 
+function toIsoDate(date: string): string {
+  return new Date(date).toISOString().split('T')[0];
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -31,7 +35,7 @@ export class EventoService {
         data: res.data.map((e: any) => ({
           id: e.id,
           nome: e.nome,
-          data: e.data,
+          data: toIsoDate(e.data),
           hora: e.hora,
           restauranteId: e.restaurante_id,
           restaurante: e.restaurante
@@ -50,7 +54,7 @@ export class EventoService {
       map(e => ({
         id: e.id,
         nome: e.nome,
-        data: e.data,
+        data: toIsoDate(e.data),
         hora: e.hora,
         restauranteId: e.restaurante_id,
         restaurante: e.restaurante


### PR DESCRIPTION
## Summary
- normalize event dates on retrieval to avoid timezone shifts
- render event and reservation dates in UTC to display the correct day

## Testing
- `npm test` (fails: Missing script: "test")
- `cd frontend && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689801ee97a0832e97791032285be77e