### PR TITLE
Add API key protection to auth routes

### DIFF
--- a/backend/middleware/apiKeyAuth.js
+++ b/backend/middleware/apiKeyAuth.js
@@ -1,0 +1,18 @@
+const { ApiError } = require('./errorHandler');
+
+function requireApiKey(req, res, next) {
+  const providedKey = req.headers['x-api-key'];
+  const expectedKey = process.env.API_KEY;
+
+  if (!expectedKey) {
+    return next(new ApiError(500, 'API key não configurada', 'API_KEY_NOT_CONFIGURED'));
+  }
+
+  if (!providedKey || providedKey !== expectedKey) {
+    return next(new ApiError(401, 'Chave de API inválida', 'INVALID_API_KEY'));
+  }
+
+  next();
+}
+
+module.exports = { requireApiKey };

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -9,6 +9,7 @@ const crypto = require('crypto');
 const { getDatabase } = require('../config/database');
 const { generateToken, authenticateToken, verifyToken, generateRefreshToken, verifyRefreshToken } = require('../middleware/auth');
 const { ApiError } = require('../middleware/errorHandler');
+const { requireApiKey } = require('../middleware/apiKeyAuth');
 
 const router = express.Router();
 
@@ -89,7 +90,7 @@ router.post('/login', async (req, res, next) => {
  * POST /auth/refresh
  * Trocar refresh token válido por novo token de acesso
  */
-router.post('/refresh', async (req, res, next) => {
+router.post('/refresh', requireApiKey, async (req, res, next) => {
   try {
     const { refreshToken } = req.body;
 
@@ -205,7 +206,7 @@ router.post('/validate', (req, res, next) => {
  * POST /auth/register
  * Registrar novo usuário (opcional)
  */
-router.post('/register', async (req, res, next) => {
+router.post('/register', requireApiKey, async (req, res, next) => {
   try {
     const { username, email, password, fullName } = req.body;
 
@@ -293,7 +294,7 @@ router.post('/register', async (req, res, next) => {
  * POST /auth/reset-password
  * Resetar senha do usuário através do email
  */
-router.post('/reset-password', async (req, res, next) => {
+router.post('/reset-password', requireApiKey, async (req, res, next) => {
   try {
     const { email, password } = req.body;
 

--- a/frontend/src/app/services/auth.ts
+++ b/frontend/src/app/services/auth.ts
@@ -40,6 +40,7 @@ export interface AuthState {
 })
 export class AuthService {
   private readonly API_URL = environment.apiUrl;
+  private readonly API_KEY = environment.apiKey;
   private readonly TOKEN_KEY = 'auth_token';
   private readonly USER_KEY = 'auth_user';
   private refreshTokenTimeout: any;
@@ -229,7 +230,9 @@ export class AuthService {
    * Atualizar token
    */
   refreshToken(): Observable<any> {
-    return this.http.post<{ token: string }>(`${this.API_URL}/auth/refresh`, {})
+    return this.http.post<{ token: string }>(`${this.API_URL}/auth/refresh`, {}, {
+      headers: { 'x-api-key': this.API_KEY }
+    })
       .pipe(
         tap(res => {
           localStorage.setItem(this.TOKEN_KEY, res.token);
@@ -311,7 +314,9 @@ export class AuthService {
    * Registrar novo usuário (opcional)
    */
   register(userData: any): Observable<any> {
-    return this.http.post(`${this.API_URL}/auth/register`, userData)
+    return this.http.post(`${this.API_URL}/auth/register`, userData, {
+      headers: { 'x-api-key': this.API_KEY }
+    })
       .pipe(
         catchError(error => {
           console.error('❌ Erro no registro:', error);
@@ -324,7 +329,9 @@ export class AuthService {
    * Resetar senha do usuário através do email
    */
   resetPassword(email: string, password: string): Observable<any> {
-    return this.http.post(`${this.API_URL}/auth/reset-password`, { email, password })
+    return this.http.post(`${this.API_URL}/auth/reset-password`, { email, password }, {
+      headers: { 'x-api-key': this.API_KEY }
+    })
       .pipe(
         catchError(error => {
           console.error('❌ Erro ao resetar senha:', error);

--- a/frontend/src/environments/environment.production.ts
+++ b/frontend/src/environments/environment.production.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  apiUrl: 'https://tematicoapi.zapchatbr.com'
+  apiUrl: 'https://tematicoapi.zapchatbr.com',
+  apiKey: '',
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,3 +1,4 @@
 export const environment = {
   apiUrl: 'http://localhost:3000',
+  apiKey: '',
 };


### PR DESCRIPTION
## Summary
- secure auth refresh, register, and reset-password routes with API key middleware
- send `x-api-key` header from frontend auth service
- add API key placeholders to Angular environments

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689895cd1c80832e921b2d49d6bc67e5