### PR TITLE
feat: add validate coduh endpoint

### DIFF
--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -1399,6 +1399,37 @@
         ]
       }
     },
+    "/reservas/validate-coduh/{coduh}": {
+      "get": {
+        "summary": "Validar reserva ativa por coduh",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "coduh",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dados da reserva e eventos relacionados"
+          },
+          "404": {
+            "description": "Reserva não encontrada"
+          }
+        },
+        "tags": [
+          "Reservas"
+        ]
+      }
+    },
     "/reservas/{id}/marcacoes": {
       "get": {
         "summary": "Listar marcações de uma reserva",


### PR DESCRIPTION
## Summary
- add endpoint to validate active reservation by coduh and include booked events
- document validate-coduh endpoint in swagger

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689a2b0a7b68832eadee03c30e8eb20f