### PR TITLE
Add contact and email to reservation registration

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -41,6 +41,8 @@ CREATE TABLE IF NOT EXISTS reservas (
   numeroreservacm VARCHAR(255) NOT NULL,
   coduh VARCHAR(255) NOT NULL,
   nome_hospede VARCHAR(255) NOT NULL,
+  contato VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
   data_checkin DATE NOT NULL,
   data_checkout DATE NOT NULL,
   qtd_hospedes INTEGER NOT NULL

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -1314,6 +1314,13 @@
                   "nome_hospede": {
                     "type": "string"
                   },
+                  "contato": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
                   "data_checkin": {
                     "type": "string",
                     "format": "date"
@@ -1329,6 +1336,8 @@
                 "required": [
                   "coduh",
                   "nome_hospede",
+                  "contato",
+                  "email",
                   "data_checkin",
                   "data_checkout",
                   "qtd_hospedes"
@@ -1497,6 +1506,13 @@
                   },
                   "nome_hospede": {
                     "type": "string"
+                  },
+                  "contato": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
                   },
                   "data_checkin": {
                     "type": "string",

--- a/frontend/src/app/components/reserva-evento/reserva-evento.html
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.html
@@ -25,6 +25,8 @@
       <div>Check-in: {{ reservaSelecionada.data_checkin | date:'dd/MM/yyyy':'UTC' }}</div>
       <div>Check-out: {{ reservaSelecionada.data_checkout | date:'dd/MM/yyyy':'UTC' }}</div>
       <div>Hóspedes: {{ reservaSelecionada.qtd_hospedes }}</div>
+      <div>Contato: {{ reservaSelecionada.contato }}</div>
+      <div>Email: {{ reservaSelecionada.email }}</div>
     </p-card>
 
     <p-message *ngIf="reservaSelecionada !== undefined && reservas.length == 0" severity="warn">

--- a/frontend/src/app/components/reservas/reserva-form.html
+++ b/frontend/src/app/components/reservas/reserva-form.html
@@ -37,6 +37,25 @@
     </div>
 
     <div class="flex flex-col gap-2">
+      <label for="contato">Contato</label>
+      <input id="contato" type="text" pInputText formControlName="contato" class="p-inputtext p-inputtext-fluid" />
+      <div class="text-red-500 text-sm" *ngIf="form.get('contato')?.hasError('required') && form.get('contato')?.touched">
+        Contato é obrigatório.
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <label for="email">Email</label>
+      <input id="email" type="email" pInputText formControlName="email" class="p-inputtext p-inputtext-fluid" />
+      <div class="text-red-500 text-sm" *ngIf="form.get('email')?.hasError('required') && form.get('email')?.touched">
+        Email é obrigatório.
+      </div>
+      <div class="text-red-500 text-sm" *ngIf="form.get('email')?.hasError('email') && form.get('email')?.touched">
+        Email inválido.
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-2">
       <label for="data_checkin">Data Check-in</label>
       <input id="data_checkin" type="date" pInputText formControlName="data_checkin" class="p-inputtext p-inputtext-fluid" />
       <div class="text-red-500 text-sm" *ngIf="form.get('data_checkin')?.hasError('required') && form.get('data_checkin')?.touched">

--- a/frontend/src/app/components/reservas/reserva-form.ts
+++ b/frontend/src/app/components/reservas/reserva-form.ts
@@ -44,6 +44,8 @@ export class ReservaFormComponent implements OnInit {
       numeroreservacm: ['', Validators.required],
       coduh: ['', Validators.required],
       nome_hospede: ['', Validators.required],
+      contato: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
       data_checkin: ['', [Validators.required, Validators.pattern(/^\d{4}-\d{2}-\d{2}$/)]],
       data_checkout: ['', [Validators.required, Validators.pattern(/^\d{4}-\d{2}-\d{2}$/)]],
       qtd_hospedes: [null, [Validators.required, Validators.pattern(/^\d+$/)]]

--- a/frontend/src/app/components/reservas/reserva-list.html
+++ b/frontend/src/app/components/reservas/reserva-list.html
@@ -23,6 +23,8 @@
         <th>Número Reserva CM</th>
         <th>Código UH</th>
         <th>Nome Hóspede</th>
+        <th>Contato</th>
+        <th>Email</th>
         <th>Check-in</th>
         <th>Check-out</th>
         <th>Qtd Hóspedes</th>
@@ -35,6 +37,8 @@
         <td>{{ r.numeroreservacm }}</td>
         <td>{{ r.coduh }}</td>
         <td>{{ r.nome_hospede }}</td>
+        <td>{{ r.contato }}</td>
+        <td>{{ r.email }}</td>
         <td>{{ r.data_checkin | date:'dd/MM/yyyy':'UTC' }}</td>
         <td>{{ r.data_checkout | date:'dd/MM/yyyy':'UTC' }}</td>
         <td>{{ r.qtd_hospedes }}</td>

--- a/frontend/src/app/models/reserva.ts
+++ b/frontend/src/app/models/reserva.ts
@@ -7,6 +7,8 @@ export interface Reserva {
   numeroreservacm: string;
   coduh: string;
   nome_hospede: string;
+  contato: string;
+  email: string;
   data_checkin: string;
   data_checkout: string;
   qtd_hospedes: number;

--- a/frontend/src/app/services/reserva-evento.service.ts
+++ b/frontend/src/app/services/reserva-evento.service.ts
@@ -13,6 +13,8 @@ export interface Reserva {
   numeroreservacm?: string;
   coduh?: string;
   nome_hospede?: string;
+  contato?: string;
+  email?: string;
   data_checkin?: string;
   data_checkout?: string;
   qtd_hospedes?: number;

--- a/frontend/src/app/services/reservas.ts
+++ b/frontend/src/app/services/reservas.ts
@@ -14,6 +14,8 @@ export interface Reserva {
   numeroreservacm: string;
   coduh: string;
   nome_hospede: string;
+  contato: string;
+  email: string;
   data_checkin: string;
   data_checkout: string;
   qtd_hospedes: number;


### PR DESCRIPTION
## Summary
- include contact and email in reservation schema and CRUD
- document new fields in Swagger
- expose contact and email fields in Angular models, forms and listing

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689b501b82ac832eada75fd6b9cab12e