### PR TITLE
Remove restaurant opening hours field

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -22,8 +22,7 @@ CREATE TABLE IF NOT EXISTS sessions (
 CREATE TABLE IF NOT EXISTS restaurantes (
   id SERIAL PRIMARY KEY,
   nome VARCHAR(255) NOT NULL,
-  capacidade INTEGER,
-  horario_funcionamento VARCHAR(255)
+  capacidade INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS eventos (

--- a/backend/database/seed.sql
+++ b/backend/database/seed.sql
@@ -3,9 +3,9 @@ INSERT INTO users (username, email, password, full_name)
 VALUES ('admin', 'admin@example.com', '$2a$12$.NifCEunTbm0Q7mpJmCS3OsKigZvlwWYNSIRn6lGfasceRI965Y6u', 'Administrador')
 ON CONFLICT (username) DO NOTHING;
 
-INSERT INTO restaurantes (id, nome, capacidade, horario_funcionamento) VALUES
-  (1, 'Restaurante Central', 100, '08:00-22:00'),
-  (2, 'Bistrô da Praça', 50, '10:00-20:00')
+INSERT INTO restaurantes (id, nome, capacidade) VALUES
+  (1, 'Restaurante Central', 100),
+  (2, 'Bistrô da Praça', 50)
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO eventos (id, nome_evento, data_evento, horario_evento, id_restaurante) VALUES

--- a/backend/routes/restaurantes.js
+++ b/backend/routes/restaurantes.js
@@ -16,7 +16,7 @@ router.get('/', (req, res, next) => {
   const offset = (page - 1) * limit;
 
   db.all(
-    'SELECT id, nome, capacidade, horario_funcionamento FROM restaurantes LIMIT ? OFFSET ?',
+    'SELECT id, nome, capacidade FROM restaurantes LIMIT ? OFFSET ?',
     [limit, offset],
     (err, rows) => {
       if (err) {
@@ -40,7 +40,7 @@ router.get('/:id', (req, res, next) => {
     return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
   }
   const db = getDatabase();
-  db.get('SELECT id, nome, capacidade, horario_funcionamento FROM restaurantes WHERE id = ?', [req.params.id], (err, row) => {
+  db.get('SELECT id, nome, capacidade FROM restaurantes WHERE id = ?', [req.params.id], (err, row) => {
     if (err) {
       console.error('❌ Erro ao obter restaurante:', err.message);
       return next(new ApiError(500, 'Erro ao obter restaurante', 'GET_RESTAURANT_ERROR', err.message));
@@ -54,20 +54,20 @@ router.get('/:id', (req, res, next) => {
 
 // Create restaurant
 router.post('/', (req, res, next) => {
-  const { nome, capacidade, horario_funcionamento } = req.body;
-  if (!nome || !horario_funcionamento || !isValidInt(capacidade)) {
-    return next(new ApiError(400, 'Nome, capacidade inteira e horário de funcionamento são obrigatórios', 'MISSING_FIELDS'));
+  const { nome, capacidade } = req.body;
+  if (!nome || !isValidInt(capacidade)) {
+    return next(new ApiError(400, 'Nome e capacidade inteira são obrigatórios', 'MISSING_FIELDS'));
   }
   const db = getDatabase();
   db.run(
-    'INSERT INTO restaurantes (nome, capacidade, horario_funcionamento) VALUES (?, ?, ?) RETURNING id',
-    [nome, capacidade, horario_funcionamento],
+    'INSERT INTO restaurantes (nome, capacidade) VALUES (?, ?) RETURNING id',
+    [nome, capacidade],
     function(err) {
       if (err) {
         console.error('❌ Erro ao criar restaurante:', err.message);
         return next(new ApiError(500, 'Erro ao criar restaurante', 'CREATE_RESTAURANT_ERROR', err.message));
       }
-      res.status(201).json({ id: this.lastID, nome, capacidade, horario_funcionamento });
+      res.status(201).json({ id: this.lastID, nome, capacidade });
     }
   );
 });
@@ -77,7 +77,7 @@ router.put('/:id', (req, res, next) => {
   if (!isValidInt(req.params.id)) {
     return next(new ApiError(400, 'ID inválido', 'INVALID_ID'));
   }
-  const { nome, capacidade, horario_funcionamento } = req.body;
+  const { nome, capacidade } = req.body;
   const fields = [];
   const values = [];
   if (nome) { fields.push('nome = ?'); values.push(nome); }
@@ -88,7 +88,6 @@ router.put('/:id', (req, res, next) => {
     fields.push('capacidade = ?');
     values.push(capacidade);
   }
-  if (horario_funcionamento) { fields.push('horario_funcionamento = ?'); values.push(horario_funcionamento); }
   if (fields.length === 0) {
     return next(new ApiError(400, 'Nenhum dado para atualizar', 'NO_FIELDS_TO_UPDATE'));
   }

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -614,15 +614,11 @@
                   },
                   "capacidade": {
                     "type": "integer"
-                  },
-                  "horario_funcionamento": {
-                    "type": "string"
                   }
                 },
                 "required": [
                   "nome",
-                  "capacidade",
-                  "horario_funcionamento"
+                  "capacidade"
                 ]
               }
             }
@@ -697,9 +693,6 @@
                   },
                   "capacidade": {
                     "type": "integer"
-                  },
-                  "horario_funcionamento": {
-                    "type": "string"
                   }
                 }
               }

--- a/frontend/src/app/components/restaurantes/restaurante-form.html
+++ b/frontend/src/app/components/restaurantes/restaurante-form.html
@@ -29,20 +29,6 @@
       </div>
     </div>
 
-    <div class="flex flex-col gap-2">
-      <label for="horarioFuncionamento">Horário de Funcionamento</label>
-      <input
-        id="horarioFuncionamento"
-        type="text"
-        pInputText
-        formControlName="horarioFuncionamento"
-        class="p-inputtext p-inputtext-fluid"
-      />
-      <div class="text-red-500 text-sm" *ngIf="form.get('horarioFuncionamento')?.hasError('required') && form.get('horarioFuncionamento')?.touched">
-        Horário de funcionamento é obrigatório.
-      </div>
-    </div>
-
     <div class="flex gap-2 pt-2">
       <button pButton type="submit" label="Salvar" [disabled]="isLoading"></button>
       <button pButton type="button" label="Cancelar" class="p-button-secondary" (click)="cancel()"></button>

--- a/frontend/src/app/components/restaurantes/restaurante-form.ts
+++ b/frontend/src/app/components/restaurantes/restaurante-form.ts
@@ -41,8 +41,7 @@ export class RestauranteFormComponent implements OnInit {
   ) {
     this.form = this.fb.group({
       nome: ['', Validators.required],
-      capacidade: [null, Validators.required],
-      horarioFuncionamento: ['', Validators.required]
+      capacidade: [null, Validators.required]
     });
   }
 

--- a/frontend/src/app/components/restaurantes/restaurante-list.html
+++ b/frontend/src/app/components/restaurantes/restaurante-list.html
@@ -22,7 +22,6 @@
       <tr>
         <th>Nome</th>
         <th>Capacidade</th>
-        <th>Horário de Funcionamento</th>
         <th>Ações</th>
       </tr>
     </ng-template>
@@ -30,7 +29,6 @@
       <tr>
         <td>{{ r.nome }}</td>
         <td>{{ r.capacidade }}</td>
-        <td>{{ r.horarioFuncionamento }}</td>
         <td>
           <button pButton icon="pi pi-pencil" class="p-button-text" (click)="editar(r.id)"></button>
           <button pButton icon="pi pi-trash" class="p-button-text p-button-danger" (click)="excluir(r.id)"></button>

--- a/frontend/src/app/models/restaurante.ts
+++ b/frontend/src/app/models/restaurante.ts
@@ -5,5 +5,4 @@ export interface Restaurante {
   id?: number;
   nome: string;
   capacidade?: number;
-  horario_funcionamento?: string;
 }

--- a/frontend/src/app/services/restaurantes.ts
+++ b/frontend/src/app/services/restaurantes.ts
@@ -12,7 +12,6 @@ export interface Restaurante {
   id?: number;
   nome: string;
   capacidade: number;
-  horarioFuncionamento: string;
 }
 
 @Injectable({
@@ -29,8 +28,7 @@ export class RestauranteService {
         data: res.data.map((r: any) => ({
           id: r.id,
           nome: r.nome,
-          capacidade: r.capacidade,
-          horarioFuncionamento: r.horario_funcionamento
+          capacidade: r.capacidade
         } as Restaurante)),
         total: res.total
       })),
@@ -46,8 +44,7 @@ export class RestauranteService {
       map(r => ({
         id: r.id,
         nome: r.nome,
-        capacidade: r.capacidade,
-        horarioFuncionamento: r.horario_funcionamento
+        capacidade: r.capacidade
       } as Restaurante)),
       catchError(error => {
         console.error('❌ Erro ao obter restaurante:', error);
@@ -59,8 +56,7 @@ export class RestauranteService {
   createRestaurante(data: Restaurante): Observable<any> {
     const payload = {
       nome: data.nome,
-      capacidade: data.capacidade,
-      horario_funcionamento: data.horarioFuncionamento
+      capacidade: data.capacidade
     };
     return this.http.post(`${this.API_URL}/restaurantes`, payload).pipe(
       catchError(error => {
@@ -72,10 +68,6 @@ export class RestauranteService {
 
   updateRestaurante(id: number, data: Partial<Restaurante>): Observable<any> {
     const payload: any = { ...data };
-    if (data.horarioFuncionamento !== undefined) {
-      payload.horario_funcionamento = data.horarioFuncionamento;
-      delete payload.horarioFuncionamento;
-    }
     return this.http.put(`${this.API_URL}/restaurantes/${id}`, payload).pipe(
       catchError(error => {
         console.error('❌ Erro ao atualizar restaurante:', error);


### PR DESCRIPTION
## Summary
- remove restaurant opening hours column from database and seed
- adjust restaurant API and docs to drop `horario_funcionamento`
- update client models, services, and forms to omit opening hours

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b50a5c424832e894c154f10d42b81