### PR TITLE
fix: block event deletion with active reservations

### DIFF
--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -936,6 +936,9 @@
           "200": {
             "description": "Evento deletado"
           },
+          "400": {
+            "description": "Evento possui reservas ativas"
+          },
           "404": {
             "description": "Evento não encontrado"
           }


### PR DESCRIPTION
## Summary
- block event removal when active reservations exist
- document deletion restriction in API docs

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689b573cf6c4832e81644a6c7c4718c5