### PR TITLE
Handle canceled reservations in event validation

### DIFF
--- a/backend/routes/eventos.js
+++ b/backend/routes/eventos.js
@@ -279,7 +279,8 @@ router.post('/:id/marcar', async (req, res, next) => {
     const { rows: [ocup] } = await db.query(
       `SELECT COALESCE(SUM(quantidade),0) AS total
          FROM eventos_reservas
-        WHERE evento_id = ?`,
+        WHERE evento_id = ?
+          AND status <> 'Cancelada'`,
       [id]
     );
     const vagas = evento.capacidade - Number(ocup.total);
@@ -307,7 +308,8 @@ router.post('/:id/marcar', async (req, res, next) => {
          FROM eventos_reservas er
          JOIN eventos e ON er.evento_id = e.id
         WHERE er.reserva_id = ?
-          AND e.data_evento = ?`,
+          AND e.data_evento = ?
+          AND er.status <> 'Cancelada'`,
       [reservaId, evento.data_evento]
     );
     if (conflitos.length > 0) {
@@ -325,7 +327,10 @@ router.post('/:id/marcar', async (req, res, next) => {
       limite = 2;
     }
     const { rows: [countRes] } = await db.query(
-      'SELECT COUNT(*)::int AS count FROM eventos_reservas WHERE reserva_id = ?',
+      `SELECT COUNT(*)::int AS count
+         FROM eventos_reservas
+        WHERE reserva_id = ?
+          AND status <> 'Cancelada'`,
       [reservaId]
     );
     if (countRes.count >= limite) {

--- a/backend/routes/eventos_reservas.js
+++ b/backend/routes/eventos_reservas.js
@@ -73,7 +73,8 @@ router.post('/', async (req, res, next) => {
     const { rows: [ocup] } = await db.query(
       `SELECT COALESCE(SUM(quantidade),0) AS total
          FROM eventos_reservas
-        WHERE evento_id = ?`,
+        WHERE evento_id = ?
+          AND status <> 'Cancelada'`,
       [eventoId]
     );
     const vagas = evento.capacidade - Number(ocup.total);
@@ -106,7 +107,10 @@ router.post('/', async (req, res, next) => {
       limite = 2;
     }
     const { rows: [countRes] } = await db.query(
-      'SELECT COUNT(*)::int AS count FROM eventos_reservas WHERE reserva_id = ?',
+      `SELECT COUNT(*)::int AS count
+         FROM eventos_reservas
+        WHERE reserva_id = ?
+          AND status <> 'Cancelada'`,
       [reservaId]
     );
     if (countRes.count >= limite) {


### PR DESCRIPTION
## Summary
- Ignore canceled event reservations when checking event capacity
- Exclude canceled reservations from limit and conflict calculations

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689b57aad75c832e98f3804cd9bebb24