### PR TITLE
Add voucher generation and lookup for event reservations

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS eventos_reservas (
   informacoes TEXT,
   quantidade INTEGER DEFAULT 0,
   status VARCHAR(20) DEFAULT 'Ativa',
+  voucher VARCHAR(10) UNIQUE NOT NULL,
   PRIMARY KEY (evento_id, reserva_id)
 );
 

--- a/backend/database/seed.sql
+++ b/backend/database/seed.sql
@@ -17,7 +17,7 @@ INSERT INTO reservas (id, idreservacm, numeroreservacm, coduh, nome_hospede, dat
   (2, 102, 'NR-002', 'UH02', 'Maria Souza', '2024-12-22', '2024-12-24', 3)
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO eventos_reservas (evento_id, reserva_id) VALUES
-  (1, 1),
-  (1, 2)
+INSERT INTO eventos_reservas (evento_id, reserva_id, voucher) VALUES
+  (1, 1, 'VX00001'),
+  (1, 2, 'VX00002')
 ON CONFLICT DO NOTHING;

--- a/backend/models/eventoReservaModel.js
+++ b/backend/models/eventoReservaModel.js
@@ -3,7 +3,7 @@ const { getDatabase } = require('../config/database');
 async function findAll() {
   const db = getDatabase();
   const { rows } = await db.query(
-    'SELECT evento_id, reserva_id, informacoes, quantidade, status FROM eventos_reservas'
+    'SELECT evento_id, reserva_id, informacoes, quantidade, status, voucher FROM eventos_reservas'
   );
   return rows;
 }
@@ -11,19 +11,45 @@ async function findAll() {
 async function findById(eventoId, reservaId) {
   const db = getDatabase();
   const { rows: [row] } = await db.query(
-    'SELECT evento_id, reserva_id, informacoes, quantidade, status FROM eventos_reservas WHERE evento_id = ? AND reserva_id = ?',
+    'SELECT evento_id, reserva_id, informacoes, quantidade, status, voucher FROM eventos_reservas WHERE evento_id = ? AND reserva_id = ?',
     [eventoId, reservaId]
   );
   return row;
 }
 
-async function create({ eventoId, reservaId, informacoes, quantidade, status }) {
+async function generateUniqueVoucher(db) {
+  let voucher;
+  let exists = true;
+  while (exists) {
+    voucher = 'VX' + Math.random().toString(36).substring(2, 8).toUpperCase();
+    const { rows } = await db.query('SELECT 1 FROM eventos_reservas WHERE voucher = ?', [voucher]);
+    exists = rows.length > 0;
+  }
+  return voucher;
+}
+
+async function findByVoucher(voucher) {
   const db = getDatabase();
-  await db.query(
-    'INSERT INTO eventos_reservas (evento_id, reserva_id, informacoes, quantidade, status) VALUES (?, ?, ?, ?, ?)',
-    [eventoId, reservaId, informacoes || null, quantidade, status || 'Ativa']
+  const { rows: [row] } = await db.query(
+    `SELECT er.evento_id, er.reserva_id, er.informacoes, er.quantidade, er.status, er.voucher,
+            e.nome_evento, e.data_evento, r.nome_hospede, r.numeroreservacm
+       FROM eventos_reservas er
+       JOIN eventos e ON er.evento_id = e.id
+       JOIN reservas r ON er.reserva_id = r.id
+      WHERE er.voucher = ?`,
+    [voucher]
   );
-  return { evento_id: eventoId, reserva_id: reservaId, informacoes: informacoes || null, quantidade, status: status || 'Ativa' };
+  return row;
+}
+
+async function create({ eventoId, reservaId, informacoes, quantidade, status, voucher }) {
+  const db = getDatabase();
+  const code = voucher || await generateUniqueVoucher(db);
+  await db.query(
+    'INSERT INTO eventos_reservas (evento_id, reserva_id, informacoes, quantidade, status, voucher) VALUES (?, ?, ?, ?, ?, ?)',
+    [eventoId, reservaId, informacoes || null, quantidade, status || 'Ativa', code]
+  );
+  return { evento_id: eventoId, reserva_id: reservaId, informacoes: informacoes || null, quantidade, status: status || 'Ativa', voucher: code };
 }
 
 async function update(eventoId, reservaId, { informacoes, quantidade, status }) {
@@ -66,6 +92,7 @@ async function remove(eventoId, reservaId) {
 module.exports = {
   findAll,
   findById,
+  findByVoucher,
   create,
   update,
   remove

--- a/backend/routes/eventos_reservas.js
+++ b/backend/routes/eventos_reservas.js
@@ -19,6 +19,19 @@ router.get('/', async (req, res, next) => {
   }
 });
 
+router.get('/voucher/:voucher', async (req, res, next) => {
+  try {
+    const row = await model.findByVoucher(req.params.voucher);
+    if (!row) {
+      return next(new ApiError(404, 'Marcação não encontrada', 'MARCACAO_NOT_FOUND'));
+    }
+    res.json(row);
+  } catch (err) {
+    console.error('❌ Erro ao obter marcação por voucher:', err.message);
+    next(new ApiError(500, 'Erro ao obter marcação', 'GET_MARCACAO_ERROR', err.message));
+  }
+});
+
 router.get('/:eventoId/:reservaId', async (req, res, next) => {
   const { eventoId, reservaId } = req.params;
   if (!isValidInt(eventoId) || !isValidInt(reservaId)) {

--- a/backend/routes/reservas.js
+++ b/backend/routes/reservas.js
@@ -154,7 +154,7 @@ router.get('/:id/marcacoes', async (req, res, next) => {
   try {
     const db = getDatabase();
     const { rows } = await db.query(
-      `SELECT er.evento_id, er.reserva_id, er.quantidade, er.informacoes, er.status,
+      `SELECT er.evento_id, er.reserva_id, er.quantidade, er.informacoes, er.status, er.voucher,
               e.nome_evento AS evento_nome, e.data_evento
          FROM eventos_reservas er
          JOIN eventos e ON er.evento_id = e.id

--- a/frontend/src/app/components/reserva-evento-list/reserva-evento-list.html
+++ b/frontend/src/app/components/reserva-evento-list/reserva-evento-list.html
@@ -11,6 +11,7 @@
         <th>Data</th>
         <th>Restaurante</th>
         <th>Reserva</th>
+        <th>Voucher</th>
         <th>Status</th>
       </tr>
     </ng-template>
@@ -20,6 +21,7 @@
         <td>{{ m.evento_data | date:'dd/MM/yyyy':'UTC' }}</td>
         <td>{{ m.restaurante }}</td>
         <td>{{ m.nome_hospede }}</td>
+        <td>{{ m.voucher }}</td>
         <td class="status-cell">
           <p-tag [value]="m.status" [severity]="getStatusSeverity(m.status)"></p-tag>
           <p-select

--- a/frontend/src/app/components/reserva-evento/reserva-evento.html
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.html
@@ -44,6 +44,7 @@
             {{ marcacao.data_evento | date:'dd/MM/yyyy':'UTC' }} -
             {{ marcacao.evento_nome }} ({{ marcacao.quantidade }} pessoas)
           </small>
+          <small>Voucher: {{ marcacao.voucher }}</small>
           <p-tag
             [value]="marcacao.status"
             [severity]="getTagSeverity(marcacao.status)"

--- a/frontend/src/app/components/reserva-evento/reserva-evento.ts
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.ts
@@ -148,8 +148,9 @@ export class ReservaEventoComponent {
     };
     
     this.service.marcar(this.eventoSelecionado.id!, payload).subscribe({
-      next: () => {
-        this.message.add({ severity: 'success', summary: 'Sucesso', detail: 'Marcação salva' });
+      next: res => {
+        const voucherMsg = res?.voucher ? ` Voucher: ${res.voucher}` : '';
+        this.message.add({ severity: 'success', summary: 'Sucesso', detail: 'Marcação salva' + voucherMsg });
         this.informacoes = '';
         this.quantidade = undefined;
         this.onEventoChange();

--- a/frontend/src/app/services/reserva-evento.service.ts
+++ b/frontend/src/app/services/reserva-evento.service.ts
@@ -43,6 +43,7 @@ export interface Marcacao {
   numero_reserva: string;
   nome_hospede: string;
   status: string;
+  voucher?: string;
 }
 
 @Injectable({


### PR DESCRIPTION
## Summary
- generate unique voucher codes for event reservations and store them
- expose lookup endpoint by voucher and include voucher in reservation responses
- show voucher codes in reservation interfaces

## Testing
- `cd backend && npm test` (fails: Missing script "test")
- `cd frontend && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689b872336b0832ea636400ef6ba2bcd