### PR TITLE
feat: add system configuration endpoints

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -62,3 +62,31 @@ CREATE TABLE IF NOT EXISTS diretrizes (
   descricao TEXT NOT NULL,
   ativo BOOLEAN DEFAULT TRUE
 );
+
+CREATE TABLE IF NOT EXISTS configuracoes (
+  id SERIAL PRIMARY KEY,
+  nome_sistema VARCHAR(255) NOT NULL,
+  webhook_whatsapp VARCHAR(255),
+  contato VARCHAR(255),
+  cnpj VARCHAR(20),
+  tempo_atualizacao_pms INTEGER,
+  nome_agenda_virtual VARCHAR(255)
+);
+
+INSERT INTO configuracoes (
+  id,
+  nome_sistema,
+  webhook_whatsapp,
+  contato,
+  cnpj,
+  tempo_atualizacao_pms,
+  nome_agenda_virtual
+) VALUES (
+  1,
+  '',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+) ON CONFLICT (id) DO NOTHING;

--- a/backend/database/seed.sql
+++ b/backend/database/seed.sql
@@ -21,3 +21,21 @@ INSERT INTO eventos_reservas (evento_id, reserva_id, voucher) VALUES
   (1, 1, 'VX00001'),
   (1, 2, 'VX00002')
 ON CONFLICT DO NOTHING;
+
+INSERT INTO configuracoes (
+  id,
+  nome_sistema,
+  webhook_whatsapp,
+  contato,
+  cnpj,
+  tempo_atualizacao_pms,
+  nome_agenda_virtual
+) VALUES (
+  1,
+  '',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+) ON CONFLICT (id) DO NOTHING;

--- a/backend/routes/configuracoes.js
+++ b/backend/routes/configuracoes.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const { getDatabase } = require('../config/database');
+const { ApiError } = require('../middleware/errorHandler');
+
+const router = express.Router();
+
+function isValidInt(value) {
+  return Number.isInteger(Number(value));
+}
+
+router.get('/', (req, res, next) => {
+  const db = getDatabase();
+  db.get(
+    'SELECT id, nome_sistema, webhook_whatsapp, contato, cnpj, tempo_atualizacao_pms, nome_agenda_virtual FROM configuracoes WHERE id = 1',
+    [],
+    (err, row) => {
+      if (err) {
+        console.error('❌ Erro ao obter configurações:', err.message);
+        return next(new ApiError(500, 'Erro ao obter configurações', 'GET_CONFIG_ERROR', err.message));
+      }
+      res.json(row);
+    }
+  );
+});
+
+router.put('/', (req, res, next) => {
+  const { nome_sistema, webhook_whatsapp, contato, cnpj, tempo_atualizacao_pms, nome_agenda_virtual } = req.body;
+  const fields = [];
+  const values = [];
+
+  if (nome_sistema !== undefined) { fields.push('nome_sistema = ?'); values.push(nome_sistema); }
+  if (webhook_whatsapp !== undefined) { fields.push('webhook_whatsapp = ?'); values.push(webhook_whatsapp); }
+  if (contato !== undefined) { fields.push('contato = ?'); values.push(contato); }
+  if (cnpj !== undefined) { fields.push('cnpj = ?'); values.push(cnpj); }
+  if (tempo_atualizacao_pms !== undefined) {
+    if (!isValidInt(tempo_atualizacao_pms)) {
+      return next(new ApiError(400, 'tempo_atualizacao_pms deve ser um inteiro', 'INVALID_TEMPO_ATUALIZACAO'));
+    }
+    fields.push('tempo_atualizacao_pms = ?');
+    values.push(tempo_atualizacao_pms);
+  }
+  if (nome_agenda_virtual !== undefined) { fields.push('nome_agenda_virtual = ?'); values.push(nome_agenda_virtual); }
+
+  if (fields.length === 0) {
+    return next(new ApiError(400, 'Nenhum dado para atualizar', 'NO_FIELDS_TO_UPDATE'));
+  }
+
+  values.push(1);
+  const sql = `UPDATE configuracoes SET ${fields.join(', ')} WHERE id = ?`;
+  const db = getDatabase();
+  db.run(sql, values, function(err) {
+    if (err) {
+      console.error('❌ Erro ao atualizar configurações:', err.message);
+      return next(new ApiError(500, 'Erro ao atualizar configurações', 'UPDATE_CONFIG_ERROR', err.message));
+    }
+    res.json({ message: 'Configurações atualizadas com sucesso' });
+  });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,6 +22,7 @@ const eventosRoutes = require('./routes/eventos');
 const reservasRoutes = require('./routes/reservas');
 const eventosReservasRoutes = require('./routes/eventos_reservas');
 const diretrizesRoutes = require('./routes/diretrizes');
+const configuracoesRoutes = require('./routes/configuracoes');
 
 // Importar middleware de autenticação
 const { authenticateToken } = require('./middleware/auth');
@@ -100,6 +101,7 @@ app.use('/eventos', authenticateToken, eventosRoutes);
 app.use('/reservas', authenticateToken, reservasRoutes);
 app.use('/eventos-reservas', authenticateToken, eventosReservasRoutes);
 app.use('/diretrizes', authenticateToken, diretrizesRoutes);
+app.use('/configuracoes', authenticateToken, configuracoesRoutes);
 
 // Rota para servir arquivos estáticos (se necessário)
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -56,6 +56,10 @@
     {
       "name": "Reservas",
       "description": "Gerenciamento de reservas"
+    },
+    {
+      "name": "Configurações",
+      "description": "Gerenciamento das configurações do sistema"
     }
   ],
   "paths": {
@@ -1661,6 +1665,47 @@
         "tags": [
           "Reservas"
         ]
+      }
+    }
+    ,
+    "/configuracoes": {
+      "get": {
+        "summary": "Obter configurações do sistema",
+        "security": [
+          { "bearerAuth": [] }
+        ],
+        "responses": {
+          "200": { "description": "Configurações obtidas" }
+        },
+        "tags": [ "Configurações" ]
+      },
+      "put": {
+        "summary": "Atualizar configurações do sistema",
+        "security": [
+          { "bearerAuth": [] }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nome_sistema": { "type": "string" },
+                  "webhook_whatsapp": { "type": "string" },
+                  "contato": { "type": "string" },
+                  "cnpj": { "type": "string" },
+                  "tempo_atualizacao_pms": { "type": "integer" },
+                  "nome_agenda_virtual": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Configurações atualizadas" }
+        },
+        "tags": [ "Configurações" ]
       }
     }
   }


### PR DESCRIPTION
## Summary
- add `configuracoes` table with default row and seed
- expose `/configuracoes` API for reading/updating system settings
- document configuration endpoints in Swagger

## Testing
- `cd backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_689b9433a580832e9b6f7cbe5dc55cff