### PR TITLE
feat: add available events search by date

### DIFF
--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -930,6 +930,30 @@
         ]
       }
     },
+    "/eventos/disponiveis": {
+      "get": {
+        "summary": "Listar eventos disponíveis por data",
+        "security": [
+          { "bearerAuth": [] }
+        ],
+        "parameters": [
+          {
+            "name": "data",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Lista de eventos disponíveis" },
+          "400": { "description": "Data inválida" }
+        },
+        "tags": [ "Eventos" ]
+      }
+    },
     "/eventos/{id}": {
       "get": {
         "summary": "Obter evento pelo ID",


### PR DESCRIPTION
## Summary
- add endpoint to list available events by date with remaining seats
- document available events endpoint in Swagger

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689cda391f00832ea363536bd8f6811f