### PR TITLE
Include restaurant schedule in available events

### DIFF
--- a/backend/routes/eventos.js
+++ b/backend/routes/eventos.js
@@ -106,13 +106,17 @@ router.get('/disponiveis', async (req, res, next) => {
   try {
     const db = getDatabase();
     const { rows } = await db.query(
-      `SELECT e.id, e.nome_evento, r.nome AS restaurante, r.capacidade,
+      `SELECT e.id,
+              e.nome_evento,
+              e.horario_evento AS hora,
+              r.nome AS restaurante,
+              r.capacidade,
               COALESCE(SUM(er.quantidade),0) AS ocupacao
          FROM eventos e
          JOIN restaurantes r ON e.id_restaurante = r.id
     LEFT JOIN eventos_reservas er ON er.evento_id = e.id AND er.status <> 'Cancelada'
         WHERE e.data_evento = ?
-        GROUP BY e.id, e.nome_evento, r.nome, r.capacidade
+        GROUP BY e.id, e.nome_evento, e.horario_evento, r.nome, r.capacidade
        HAVING (r.capacidade - COALESCE(SUM(er.quantidade),0)) > 0`,
       [data]
     );
@@ -123,7 +127,8 @@ router.get('/disponiveis', async (req, res, next) => {
         restaurante: row.restaurante,
         vagas,
         id: row.id,
-        nome: row.nome_evento
+        nome: row.nome_evento,
+        hora: row.hora
       };
     });
     res.json(result);

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -948,7 +948,30 @@
           }
         ],
         "responses": {
-          "200": { "description": "Lista de eventos disponíveis" },
+          "200": {
+            "description": "Lista de eventos disponíveis",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "disponibilidade": { "type": "boolean" },
+                      "restaurante": { "type": "string" },
+                      "vagas": { "type": "integer" },
+                      "id": { "type": "integer" },
+                      "nome": { "type": "string" },
+                      "hora": {
+                        "type": "string",
+                        "pattern": "^\\\d{2}:\\\d{2}$"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "400": { "description": "Data inválida" }
         },
         "tags": [ "Eventos" ]


### PR DESCRIPTION
## Summary
- return event time in `/eventos/disponiveis`
- document `hora` field in swagger

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd backend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cde4459ec832eab05da6a54be23c4