### PR TITLE
feat: avoid duplicate event reservations

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -47,14 +47,16 @@ CREATE TABLE IF NOT EXISTS reservas (
   qtd_hospedes INTEGER NOT NULL
 );
 
+ALTER TABLE IF EXISTS eventos_reservas
+  DROP CONSTRAINT IF EXISTS eventos_reservas_pkey;
+
 CREATE TABLE IF NOT EXISTS eventos_reservas (
   evento_id INTEGER NOT NULL REFERENCES eventos(id) ON DELETE CASCADE,
   reserva_id INTEGER NOT NULL REFERENCES reservas(id) ON DELETE CASCADE,
   informacoes TEXT,
   quantidade INTEGER DEFAULT 0,
   status VARCHAR(20) DEFAULT 'Ativa',
-  voucher VARCHAR(10) UNIQUE NOT NULL,
-  PRIMARY KEY (evento_id, reserva_id)
+  voucher VARCHAR(10) UNIQUE NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS diretrizes (


### PR DESCRIPTION
## Summary
- check for existing active reservation per event before insert
- prevent multiple active event reservations while allowing other statuses
- drop database primary key so code logic handles duplicates

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e2e5b8e64832e8c821b7247ddcd42