### PR TITLE
Handle validation errors with HTTP 200 and success flag

### DIFF
--- a/backend/middleware/errorHandler.js
+++ b/backend/middleware/errorHandler.js
@@ -18,6 +18,14 @@ function errorHandler(err, req, res, next) {
   }
 
   const status = err.statusCode || 500;
+
+  if (status === 400) {
+    const response = { success: false, errors: [err.message] };
+    if (err.code) response.code = err.code;
+    if (err.details) response.details = err.details;
+    return res.status(200).json(response);
+  }
+
   const response = { error: err.message || 'Erro interno do servidor' };
   if (err.code) response.code = err.code;
   if (err.details) response.details = err.details;


### PR DESCRIPTION
## Summary
- adjust global error handler to return HTTP 200 with `success: false` and error messages for validation failures

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f72cbfd44832ea4efa7215a74fd04