### PR TITLE
feat: add description to restaurant CRUD

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS sessions (
 CREATE TABLE IF NOT EXISTS restaurantes (
   id SERIAL PRIMARY KEY,
   nome VARCHAR(255) NOT NULL,
-  capacidade INTEGER
+  capacidade INTEGER,
+  descricao TEXT
 );
 
 CREATE TABLE IF NOT EXISTS eventos (

--- a/backend/database/seed.sql
+++ b/backend/database/seed.sql
@@ -3,9 +3,9 @@ INSERT INTO users (username, email, password, full_name)
 VALUES ('admin', 'admin@example.com', '$2a$12$.NifCEunTbm0Q7mpJmCS3OsKigZvlwWYNSIRn6lGfasceRI965Y6u', 'Administrador')
 ON CONFLICT (username) DO NOTHING;
 
-INSERT INTO restaurantes (id, nome, capacidade) VALUES
-  (1, 'Restaurante Central', 100),
-  (2, 'Bistrô da Praça', 50)
+INSERT INTO restaurantes (id, nome, capacidade, descricao) VALUES
+  (1, 'Restaurante Central', 100, 'Restaurante principal do hotel'),
+  (2, 'Bistrô da Praça', 50, 'Charmoso bistrô na praça')
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO eventos (id, nome_evento, data_evento, horario_evento, id_restaurante) VALUES

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -622,6 +622,9 @@
                   },
                   "capacidade": {
                     "type": "integer"
+                  },
+                  "descricao": {
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -701,6 +704,9 @@
                   },
                   "capacidade": {
                     "type": "integer"
+                  },
+                  "descricao": {
+                    "type": "string"
                   }
                 }
               }

--- a/frontend/src/app/components/restaurantes/restaurante-form.html
+++ b/frontend/src/app/components/restaurantes/restaurante-form.html
@@ -16,6 +16,17 @@
     </div>
 
     <div class="flex flex-col gap-2">
+      <label for="descricao">Descrição</label>
+      <input
+        id="descricao"
+        type="text"
+        pInputText
+        formControlName="descricao"
+        class="p-inputtext p-inputtext-fluid"
+      />
+    </div>
+
+    <div class="flex flex-col gap-2">
       <label for="capacidade">Capacidade</label>
       <input
         id="capacidade"

--- a/frontend/src/app/components/restaurantes/restaurante-form.ts
+++ b/frontend/src/app/components/restaurantes/restaurante-form.ts
@@ -41,7 +41,8 @@ export class RestauranteFormComponent implements OnInit {
   ) {
     this.form = this.fb.group({
       nome: ['', Validators.required],
-      capacidade: [null, Validators.required]
+      capacidade: [null, Validators.required],
+      descricao: ['']
     });
   }
 

--- a/frontend/src/app/components/restaurantes/restaurante-list.html
+++ b/frontend/src/app/components/restaurantes/restaurante-list.html
@@ -21,6 +21,7 @@
     <ng-template pTemplate="header">
       <tr>
         <th>Nome</th>
+        <th>Descrição</th>
         <th>Capacidade</th>
         <th>Ações</th>
       </tr>
@@ -28,6 +29,7 @@
     <ng-template pTemplate="body" let-r>
       <tr>
         <td>{{ r.nome }}</td>
+        <td>{{ r.descricao }}</td>
         <td>{{ r.capacidade }}</td>
         <td>
           <button pButton icon="pi pi-pencil" class="p-button-text" (click)="editar(r.id)"></button>

--- a/frontend/src/app/models/restaurante.ts
+++ b/frontend/src/app/models/restaurante.ts
@@ -5,4 +5,5 @@ export interface Restaurante {
   id?: number;
   nome: string;
   capacidade?: number;
+  descricao?: string;
 }

--- a/frontend/src/app/services/restaurantes.ts
+++ b/frontend/src/app/services/restaurantes.ts
@@ -12,6 +12,7 @@ export interface Restaurante {
   id?: number;
   nome: string;
   capacidade: number;
+  descricao?: string;
 }
 
 @Injectable({
@@ -28,7 +29,8 @@ export class RestauranteService {
         data: res.data.map((r: any) => ({
           id: r.id,
           nome: r.nome,
-          capacidade: r.capacidade
+          capacidade: r.capacidade,
+          descricao: r.descricao
         } as Restaurante)),
         total: res.total
       })),
@@ -44,7 +46,8 @@ export class RestauranteService {
       map(r => ({
         id: r.id,
         nome: r.nome,
-        capacidade: r.capacidade
+        capacidade: r.capacidade,
+        descricao: r.descricao
       } as Restaurante)),
       catchError(error => {
         console.error('❌ Erro ao obter restaurante:', error);
@@ -56,7 +59,8 @@ export class RestauranteService {
   createRestaurante(data: Restaurante): Observable<any> {
     const payload = {
       nome: data.nome,
-      capacidade: data.capacidade
+      capacidade: data.capacidade,
+      descricao: data.descricao
     };
     return this.http.post(`${this.API_URL}/restaurantes`, payload).pipe(
       catchError(error => {


### PR DESCRIPTION
## Summary
- add description column to restaurant table and seed data
- expose description field in restaurant API and listing
- capture and display descriptions on restaurant forms and tables

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a083689d08832e81f30dc203250204