### PR TITLE
Handle new backend error response format

### DIFF
--- a/frontend/src/app/components/reserva-evento/reserva-evento.ts
+++ b/frontend/src/app/components/reserva-evento/reserva-evento.ts
@@ -15,7 +15,7 @@ import { DatePickerModule } from 'primeng/datepicker';
 import { MessageModule } from 'primeng/message';
 import { TagModule } from 'primeng/tag';
 import { MessageService } from 'primeng/api';
-
+import { extractErrorMessage } from '../../utils';
 import { ReservaEventoService, Reserva, Evento, Disponibilidade } from '../../services/reserva-evento.service';
 
 @Component({
@@ -157,7 +157,7 @@ export class ReservaEventoComponent {
         this.carregarMarcacoesExistentes();
       },
       error: err => {
-        const detail = err.error?.error || 'Falha ao salvar marcação';
+        const detail = extractErrorMessage(err);
         this.message.add({ severity: 'error', summary: 'Erro', detail });
       },
     });
@@ -176,7 +176,7 @@ export class ReservaEventoComponent {
           this.carregarMarcacoesExistentes();
         },
         error: err => {
-          const detail = err.error?.error || 'Falha ao atualizar status';
+          const detail = extractErrorMessage(err);
           this.message.add({ severity: 'error', summary: 'Erro', detail });
         },
       });
@@ -264,7 +264,7 @@ export class ReservaEventoComponent {
           window.open(url, '_blank');
         },
         error: err => {
-          const detail = err.error?.error || 'Falha ao obter voucher';
+          const detail = extractErrorMessage(err);
           this.message.add({ severity: 'error', summary: 'Erro', detail });
         }
       });

--- a/frontend/src/app/interceptors/error-interceptor.ts
+++ b/frontend/src/app/interceptors/error-interceptor.ts
@@ -2,13 +2,14 @@ import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { MessageService } from 'primeng/api';
 import { catchError, throwError } from 'rxjs';
+import { extractErrorMessage } from '../utils';
 
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const messageService = inject(MessageService);
 
   return next(req).pipe(
     catchError((err: HttpErrorResponse) => {
-      const detail = err.error?.error || err.error?.message || 'Erro desconhecido';
+      const detail = extractErrorMessage(err);
       messageService.add({ severity: 'error', summary: 'Erro', detail });
       return throwError(() => err);
     })

--- a/frontend/src/app/utils/index.ts
+++ b/frontend/src/app/utils/index.ts
@@ -2,5 +2,8 @@
  * Extrai uma mensagem de erro padronizada a partir de um objeto de erro.
  */
 export function extractErrorMessage(err: any): string {
-  return err?.error?.error || err?.error?.message || 'Mensagem padrão';
+  if (Array.isArray(err?.error?.errors)) {
+    return err.error.errors.join(', ');
+  }
+  return err?.error?.error || err?.error?.message || 'Erro desconhecido';
 }


### PR DESCRIPTION
## Summary
- Parse backend error arrays with `extractErrorMessage`
- Use shared error extraction in HTTP error interceptor
- Use shared error extraction in reservation event component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a093e54b0c832eb9c56ee6d32a4cd5