### PR TITLE
Allow multiple guest event reservations with single active

### DIFF
--- a/backend/routes/eventos.js
+++ b/backend/routes/eventos.js
@@ -343,18 +343,18 @@ router.post('/:id/marcar', async (req, res, next) => {
       return next(new ApiError(400, 'Marcação ativa já existe para este evento', 'MARCACAO_DUPLICADA'));
     }
 
-    // Rule 4: não pode existir reserva do mesmo hóspede para o mesmo evento
+    // Rule 4: hóspede só pode ter uma marcação ativa para o mesmo evento
     const { rows: guestConflict } = await db.query(
       `SELECT 1
          FROM eventos_reservas er
          JOIN reservas r ON er.reserva_id = r.id
         WHERE er.evento_id = ?
           AND r.nome_hospede = ?
-          AND er.status <> 'Cancelada'`,
+          AND er.status = 'Ativa'`,
       [id, reserva.nome_hospede]
     );
     if (guestConflict.length > 0) {
-      return next(new ApiError(400, 'Hóspede já possui reserva para este evento', 'HOSPEDE_DUPLICADO'));
+      return next(new ApiError(400, 'Hóspede já possui marcação ativa para este evento', 'HOSPEDE_DUPLICADO'));
     }
 
     // Rule 5: mesma reserva não pode ser vinculada a mais de um evento no mesmo dia

--- a/backend/routes/eventos_reservas.js
+++ b/backend/routes/eventos_reservas.js
@@ -110,18 +110,18 @@ router.post('/', async (req, res, next) => {
       }
     }
 
-    // Rule 4: não pode existir reserva do mesmo hóspede para o mesmo evento
+    // Rule 4: hóspede só pode ter uma marcação ativa para o mesmo evento
     const { rows: guestConflict } = await db.query(
       `SELECT 1
          FROM eventos_reservas er
          JOIN reservas r ON er.reserva_id = r.id
         WHERE er.evento_id = ?
           AND r.nome_hospede = ?
-          AND er.status <> 'Cancelada'`,
+          AND er.status = 'Ativa'`,
       [eventoId, reserva.nome_hospede]
     );
     if (guestConflict.length > 0) {
-      return next(new ApiError(400, 'Hóspede já possui reserva para este evento', 'HOSPEDE_DUPLICADO'));
+      return next(new ApiError(400, 'Hóspede já possui marcação ativa para este evento', 'HOSPEDE_DUPLICADO'));
     }
 
     // Rule 5: limite de marcações conforme duração da reserva


### PR DESCRIPTION
## Summary
- permit multiple reservations by the same guest for an event while enforcing only one active reservation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a09a5d0d10832e9b4c2206d232b6fb