### PR TITLE
feat: add configurable booking rules

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -66,6 +66,22 @@ CREATE TABLE IF NOT EXISTS diretrizes (
   ativo BOOLEAN DEFAULT TRUE
 );
 
+CREATE TABLE IF NOT EXISTS regras_validacao (
+  id SERIAL PRIMARY KEY,
+  chave VARCHAR(50) UNIQUE NOT NULL,
+  descricao TEXT NOT NULL,
+  ativo BOOLEAN DEFAULT TRUE
+);
+
+INSERT INTO regras_validacao (chave, descricao, ativo) VALUES
+  ('QUANTIDADE_RESERVA', 'Quantidade não pode exceder número de hóspedes da reserva', TRUE),
+  ('CAPACIDADE_EVENTO', 'Total de participantes não pode ultrapassar capacidade do restaurante', TRUE),
+  ('MARCACAO_DUPLICADA_EVENTO_RESERVA', 'Não permitir mais de uma marcação ativa para o mesmo evento e reserva', TRUE),
+  ('HOSPEDE_DUPLICADO_EVENTO', 'Um hóspede não pode ter mais de uma marcação ativa para o mesmo evento', TRUE),
+  ('RESERVA_DUPLICADA_DIA', 'A reserva não pode ser vinculada a outro evento na mesma data', TRUE),
+  ('LIMITE_MARCACOES_ESTADIA', 'Limite de marcações conforme duração da estadia', TRUE)
+ON CONFLICT (chave) DO NOTHING;
+
 CREATE TABLE IF NOT EXISTS configuracoes (
   id SERIAL PRIMARY KEY,
   nome_sistema VARCHAR(255) NOT NULL,

--- a/backend/routes/eventos.js
+++ b/backend/routes/eventos.js
@@ -3,6 +3,12 @@ const { getDatabase } = require('../config/database');
 const { ApiError } = require('../middleware/errorHandler');
 const eventoReservaModel = require('../models/eventoReservaModel');
 
+async function getActiveRules() {
+  const db = getDatabase();
+  const { rows } = await db.query('SELECT chave FROM regras_validacao WHERE ativo = TRUE');
+  return new Set(rows.map(r => r.chave));
+}
+
 const router = express.Router();
 
 function isValidDate(value) {
@@ -105,6 +111,7 @@ router.get('/disponiveis', async (req, res, next) => {
   }
   try {
     const db = getDatabase();
+    const rules = await getActiveRules();
     const { rows } = await db.query(
       `SELECT e.id,
               e.nome_evento,
@@ -313,83 +320,93 @@ router.post('/:id/marcar', async (req, res, next) => {
     }
 
     // Rule 1: quantidade não pode ultrapassar número de hóspedes da reserva
-    if (quantidade > reserva.qtd_hospedes) {
+    if (rules.has('QUANTIDADE_RESERVA') && quantidade > reserva.qtd_hospedes) {
       return next(new ApiError(400, 'Quantidade excede número de hóspedes da reserva', 'QUANTIDADE_EXCEDE_RESERVA'));
     }
 
     // Rule 2: total de hóspedes no evento não pode ultrapassar capacidade
-    const { rows: [ocup] } = await db.query(
-      `SELECT COALESCE(SUM(quantidade),0) AS total
-         FROM eventos_reservas
-        WHERE evento_id = ?
-          AND status <> 'Cancelada'`,
-      [id]
-    );
-    const vagas = evento.capacidade - Number(ocup.total);
-    if (quantidade > vagas) {
-      return next(new ApiError(400, 'Capacidade do evento excedida', 'CAPACIDADE_EXCEDIDA'));
+    if (rules.has('CAPACIDADE_EVENTO')) {
+      const { rows: [ocup] } = await db.query(
+        `SELECT COALESCE(SUM(quantidade),0) AS total
+           FROM eventos_reservas
+          WHERE evento_id = ?
+            AND status <> 'Cancelada'`,
+        [id]
+      );
+      const vagas = evento.capacidade - Number(ocup.total);
+      if (quantidade > vagas) {
+        return next(new ApiError(400, 'Capacidade do evento excedida', 'CAPACIDADE_EXCEDIDA'));
+      }
     }
 
     // Rule 3: não pode existir mais de uma marcação ativa para o mesmo evento e reserva
-    const { rows: duplicated } = await db.query(
-      `SELECT 1
-         FROM eventos_reservas er
-        WHERE er.evento_id = ?
-          AND er.reserva_id = ?
-          AND er.status = 'Ativa'`,
-      [id, reservaId]
-    );
-    if (duplicated.length > 0) {
-      return next(new ApiError(400, 'Marcação ativa já existe para este evento', 'MARCACAO_DUPLICADA'));
+    if (rules.has('MARCACAO_DUPLICADA_EVENTO_RESERVA')) {
+      const { rows: duplicated } = await db.query(
+        `SELECT 1
+           FROM eventos_reservas er
+          WHERE er.evento_id = ?
+            AND er.reserva_id = ?
+            AND er.status = 'Ativa'`,
+        [id, reservaId]
+      );
+      if (duplicated.length > 0) {
+        return next(new ApiError(400, 'Marcação ativa já existe para este evento', 'MARCACAO_DUPLICADA'));
+      }
     }
 
     // Rule 4: hóspede só pode ter uma marcação ativa para o mesmo evento
-    const { rows: guestConflict } = await db.query(
-      `SELECT 1
-         FROM eventos_reservas er
-         JOIN reservas r ON er.reserva_id = r.id
-        WHERE er.evento_id = ?
-          AND r.nome_hospede = ?
-          AND er.status = 'Ativa'`,
-      [id, reserva.nome_hospede]
-    );
-    if (guestConflict.length > 0) {
-      return next(new ApiError(400, 'Hóspede já possui marcação ativa para este evento', 'HOSPEDE_DUPLICADO'));
+    if (rules.has('HOSPEDE_DUPLICADO_EVENTO')) {
+      const { rows: guestConflict } = await db.query(
+        `SELECT 1
+           FROM eventos_reservas er
+           JOIN reservas r ON er.reserva_id = r.id
+          WHERE er.evento_id = ?
+            AND r.nome_hospede = ?
+            AND er.status = 'Ativa'`,
+        [id, reserva.nome_hospede]
+      );
+      if (guestConflict.length > 0) {
+        return next(new ApiError(400, 'Hóspede já possui marcação ativa para este evento', 'HOSPEDE_DUPLICADO'));
+      }
     }
 
     // Rule 5: mesma reserva não pode ser vinculada a mais de um evento no mesmo dia
-    const { rows: conflitos } = await db.query(
-      `SELECT 1
-         FROM eventos_reservas er
-         JOIN eventos e ON er.evento_id = e.id
-        WHERE er.reserva_id = ?
-          AND e.data_evento = ?
-          AND er.status <> 'Cancelada'`,
-      [reservaId, evento.data_evento]
-    );
-    if (conflitos.length > 0) {
-      return next(new ApiError(400, 'Reserva já vinculada a outro evento neste dia', 'RESERVA_DUPLICADA'));
+    if (rules.has('RESERVA_DUPLICADA_DIA')) {
+      const { rows: conflitos } = await db.query(
+        `SELECT 1
+           FROM eventos_reservas er
+           JOIN eventos e ON er.evento_id = e.id
+          WHERE er.reserva_id = ?
+            AND e.data_evento = ?
+            AND er.status <> 'Cancelada'`,
+        [reservaId, evento.data_evento]
+      );
+      if (conflitos.length > 0) {
+        return next(new ApiError(400, 'Reserva já vinculada a outro evento neste dia', 'RESERVA_DUPLICADA'));
+      }
     }
 
     // Rule 6: limite de marcações conforme duração da reserva
-    const checkin = new Date(reserva.data_checkin);
-    const checkout = new Date(reserva.data_checkout);
-    const diff = Math.max(1, Math.ceil((checkout - checkin) / (1000 * 60 * 60 * 24)));
-    let limite = 1;
-    if (diff >= 7) {
-      limite = 3;
-    } else if (diff >= 3) {
-      limite = 2;
-    }
-    const { rows: [countRes] } = await db.query(
-      `SELECT COUNT(*)::int AS count
-         FROM eventos_reservas
-        WHERE reserva_id = ?
-          AND status <> 'Cancelada'`,
-      [reservaId]
-    );
-    if (countRes.count >= limite) {
-      return next(new ApiError(400, 'Limite de marcações atingido para a reserva', 'LIMITE_MARCACOES'));
+    if (rules.has('LIMITE_MARCACOES_ESTADIA')) {
+      const checkin = new Date(reserva.data_checkin);
+      const checkout = new Date(reserva.data_checkout);
+      const diff = Math.max(1, Math.ceil((checkout - checkin) / (1000 * 60 * 60 * 24)));
+      let limite = 1;
+      if (diff >= 7) {
+        limite = 3;
+      } else if (diff >= 3) {
+        limite = 2;
+      }
+      const { rows: [countRes] } = await db.query(
+        `SELECT COUNT(*)::int AS count
+           FROM eventos_reservas
+          WHERE reserva_id = ?
+            AND status <> 'Cancelada'`,
+        [reservaId]
+      );
+      if (countRes.count >= limite) {
+        return next(new ApiError(400, 'Limite de marcações atingido para a reserva', 'LIMITE_MARCACOES'));
+      }
     }
 
     const created = await eventoReservaModel.create({

--- a/backend/routes/regras.js
+++ b/backend/routes/regras.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const { getDatabase } = require('../config/database');
+const { ApiError } = require('../middleware/errorHandler');
+
+const router = express.Router();
+
+router.get('/', async (req, res, next) => {
+  try {
+    const db = getDatabase();
+    const { rows } = await db.query('SELECT id, chave, descricao, ativo FROM regras_validacao ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    console.error('❌ Erro ao listar regras:', err.message);
+    next(new ApiError(500, 'Erro ao listar regras', 'LIST_REGRAS_ERROR', err.message));
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  const { id } = req.params;
+  const { ativo } = req.body;
+  if (ativo === undefined) {
+    return next(new ApiError(400, 'Campo ativo é obrigatório', 'MISSING_FIELDS'));
+  }
+  try {
+    const db = getDatabase();
+    const result = await db.query('UPDATE regras_validacao SET ativo = ? WHERE id = ?', [ativo, id]);
+    if (result.rowCount === 0) {
+      return next(new ApiError(404, 'Regra não encontrada', 'RULE_NOT_FOUND'));
+    }
+    res.json({ message: 'Regra atualizada com sucesso' });
+  } catch (err) {
+    console.error('❌ Erro ao atualizar regra:', err.message);
+    next(new ApiError(500, 'Erro ao atualizar regra', 'UPDATE_REGRA_ERROR', err.message));
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -23,6 +23,7 @@ const reservasRoutes = require('./routes/reservas');
 const eventosReservasRoutes = require('./routes/eventos_reservas');
 const diretrizesRoutes = require('./routes/diretrizes');
 const configuracoesRoutes = require('./routes/configuracoes');
+const regrasRoutes = require('./routes/regras');
 
 // Importar middleware de autenticação
 const { authenticateToken } = require('./middleware/auth');
@@ -102,6 +103,7 @@ app.use('/reservas', authenticateToken, reservasRoutes);
 app.use('/eventos-reservas', authenticateToken, eventosReservasRoutes);
 app.use('/diretrizes', authenticateToken, diretrizesRoutes);
 app.use('/configuracoes', authenticateToken, configuracoesRoutes);
+app.use('/regras', authenticateToken, regrasRoutes);
 
 // Rota para servir arquivos estáticos (se necessário)
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -37,6 +37,7 @@ export const routes: Routes = [
       { path: 'diretrizes', loadComponent: () => import('./components/diretrizes/diretriz-list').then(m => m.DiretrizListComponent) },
       { path: 'diretrizes/novo', loadComponent: () => import('./components/diretrizes/diretriz-form').then(m => m.DiretrizFormComponent) },
       { path: 'diretrizes/:id', loadComponent: () => import('./components/diretrizes/diretriz-form').then(m => m.DiretrizFormComponent) },
+      { path: 'regras', loadComponent: () => import('./components/regras/regra-list').then(m => m.RegraListComponent) },
       { path: 'eventos', loadComponent: () => import('./components/eventos/evento-list').then(m => m.EventoListComponent) },
       { path: 'eventos/novo', loadComponent: () => import('./components/eventos/evento-form').then(m => m.EventoFormComponent) },
       { path: 'eventos/em-massa', loadComponent: () => import('./components/eventos/evento-bulk-form').then(m => m.EventoBulkFormComponent) },

--- a/frontend/src/app/components/regras/regra-list.html
+++ b/frontend/src/app/components/regras/regra-list.html
@@ -1,0 +1,19 @@
+<p-card>
+  <p-table [value]="regras" [loading]="isLoading">
+    <ng-template pTemplate="header">
+      <tr>
+        <th>Descrição</th>
+        <th>Ativo</th>
+      </tr>
+    </ng-template>
+    <ng-template pTemplate="body" let-regra>
+      <tr>
+        <td>{{ regra.descricao }}</td>
+        <td>
+          <p-inputSwitch [ngModel]="regra.ativo" (onChange)="toggle(regra)"></p-inputSwitch>
+        </td>
+      </tr>
+    </ng-template>
+  </p-table>
+  <p-toast></p-toast>
+</p-card>

--- a/frontend/src/app/components/regras/regra-list.scss
+++ b/frontend/src/app/components/regras/regra-list.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/frontend/src/app/components/regras/regra-list.ts
+++ b/frontend/src/app/components/regras/regra-list.ts
@@ -1,0 +1,52 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RegraService, Regra } from '../../services/regras';
+import { TableModule } from 'primeng/table';
+import { InputSwitchModule } from 'primeng/inputswitch';
+import { CardModule } from 'primeng/card';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+
+@Component({
+  selector: 'app-regra-list',
+  standalone: true,
+  imports: [CommonModule, TableModule, InputSwitchModule, CardModule, ToastModule],
+  providers: [MessageService],
+  templateUrl: './regra-list.html',
+  styleUrls: ['./regra-list.scss']
+})
+export class RegraListComponent implements OnInit {
+  regras: Regra[] = [];
+  isLoading = false;
+
+  constructor(private service: RegraService, private messageService: MessageService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading = true;
+    this.service.getRegras().subscribe({
+      next: data => {
+        this.regras = data;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.isLoading = false;
+      }
+    });
+  }
+
+  toggle(regra: Regra): void {
+    this.service.updateRegra(regra.id, !regra.ativo).subscribe({
+      next: () => {
+        regra.ativo = !regra.ativo;
+        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: 'Regra atualizada' });
+      },
+      error: () => {
+        this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao atualizar regra' });
+      }
+    });
+  }
+}

--- a/frontend/src/app/services/regras.ts
+++ b/frontend/src/app/services/regras.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { Observable } from 'rxjs';
+
+export interface Regra {
+  id: number;
+  chave: string;
+  descricao: string;
+  ativo: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RegraService {
+  private readonly API_URL = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getRegras(): Observable<Regra[]> {
+    return this.http.get<Regra[]>(`${this.API_URL}/regras`);
+  }
+
+  updateRegra(id: number, ativo: boolean): Observable<any> {
+    return this.http.put(`${this.API_URL}/regras/${id}`, { ativo });
+  }
+}


### PR DESCRIPTION
## Summary
- store event booking validation rules in database
- expose CRUD API and UI to toggle rules
- apply only active rules when associating events to reservations

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a47ad3469c832eb13a7c36f25c234d